### PR TITLE
Stop building with Jack.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'me.tatarka:gradle-retrolambda:3.5.0'
 
         // NOTE: Do not place your application dependencies here.
     }
@@ -18,6 +19,7 @@ repositories {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileSdkVersion 24
@@ -30,9 +32,6 @@ android {
         versionCode 1
         versionName "0.0.1"
         setProperty("archivesBaseName", "mobly-bundled-snippets")
-        jackOptions {
-            enabled true
-        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
jack doesn't produce a classes.jar and is slower than the old toolchain.