### PR TITLE
Target sdk 22 so we don't have to deal with runtime permissions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ android {
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
         minSdkVersion 11
-        targetSdkVersion 24
+        // Set target to 22 to avoid having to deal with runtime permissions.
+        targetSdkVersion 22
         versionCode 1
         versionName "0.0.1"
         setProperty("archivesBaseName", "mobly-bundled-snippets")


### PR DESCRIPTION
-g avoids them but users have to remember to specify that, plus Gradle
warns you that you are calling things in an invalid way unless you request
permissions through the runtime system.