### PR TITLE
Remove unused var mIsScanning from WifiManagerSnippet

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -48,7 +48,6 @@ public class WifiManagerSnippet implements Snippet {
     private final Context mContext;
     private static final String TAG = "WifiManagerSnippet";
     private final JsonSerializer mJsonSerializer = new JsonSerializer();
-    private volatile boolean mIsScanning = false;
     private volatile boolean mIsScanResultAvailable = false;
 
     public WifiManagerSnippet() {
@@ -109,7 +108,6 @@ public class WifiManagerSnippet implements Snippet {
                 new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION));
         wifiStartScan();
         mIsScanResultAvailable = false;
-        mIsScanning = true;
         if (!Utils.waitUntil(() -> mIsScanResultAvailable, 2 * 60)) {
             throw new WifiManagerSnippetException(
                     "Failed to get scan results after 2min, timeout!");
@@ -250,7 +248,6 @@ public class WifiManagerSnippet implements Snippet {
         public void onReceive(Context c, Intent intent) {
             String action = intent.getAction();
             if (action.equals(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION)) {
-                mIsScanning = false;
                 mIsScanResultAvailable = true;
             }
         }


### PR DESCRIPTION
mIsScanning is unused since mIsScanResultAvailable is used as the internal check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/32)
<!-- Reviewable:end -->
