### PR TITLE
Added snippet to enable/disable wifi-verbose logging on API 21+

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -16,7 +16,6 @@
 
 package com.google.android.mobly.snippet.bundled;
 
-import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -16,6 +16,7 @@
 
 package com.google.android.mobly.snippet.bundled;
 
+import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -224,6 +225,19 @@ public class WifiManagerSnippet implements Snippet {
             networks.add(mJsonSerializer.toJson(config));
         }
         return networks;
+    }
+
+    @TargetApi(21)
+    @Rpc(description = "Enable or disable wifi verbose logging.")
+    public void setWifiVerboseLogging(boolean enabled) throws Throwable {
+        try {
+            mWifiManager
+                    .getClass()
+                    .getDeclaredMethod("enableVerboseLogging", int.class)
+                    .invoke(mWifiManager, enabled ? 1 : 0);
+        } catch (NoSuchMethodException | InvocationTargetException e) {
+            throw e.getCause();
+        }
     }
 
     @Rpc(

--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -24,6 +24,7 @@ import android.content.IntentFilter;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
+import android.os.Build;
 import android.support.annotation.Nullable;
 import android.support.test.InstrumentationRegistry;
 import com.google.android.mobly.snippet.Snippet;
@@ -31,6 +32,7 @@ import com.google.android.mobly.snippet.bundled.utils.JsonDeserializer;
 import com.google.android.mobly.snippet.bundled.utils.JsonSerializer;
 import com.google.android.mobly.snippet.bundled.utils.Utils;
 import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.rpc.RpcMinSdk;
 import com.google.android.mobly.snippet.util.Log;
 import java.util.ArrayList;
 import org.json.JSONArray;
@@ -223,7 +225,7 @@ public class WifiManagerSnippet implements Snippet {
         return networks;
     }
 
-    @TargetApi(21)
+    @RpcMinSdk(Build.VERSION_CODES.LOLLIPOP)
     @Rpc(description = "Enable or disable wifi verbose logging.")
     public void setWifiVerboseLogging(boolean enable) throws Throwable {
         Utils.invokeByReflection(mWifiManager, "enableVerboseLogging", enable ? 1 : 0);

--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -226,7 +226,7 @@ public class WifiManagerSnippet implements Snippet {
 
     @RpcMinSdk(Build.VERSION_CODES.LOLLIPOP)
     @Rpc(description = "Enable or disable wifi verbose logging.")
-    public void setWifiVerboseLogging(boolean enable) throws Throwable {
+    public void wifiSetVerboseLogging(boolean enable) throws Throwable {
         Utils.invokeByReflection(mWifiManager, "enableVerboseLogging", enable ? 1 : 0);
     }
 

--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -229,13 +229,13 @@ public class WifiManagerSnippet implements Snippet {
 
     @TargetApi(21)
     @Rpc(description = "Enable or disable wifi verbose logging.")
-    public void setWifiVerboseLogging(boolean enabled) throws Throwable {
+    public void setWifiVerboseLogging(boolean enable) throws Throwable {
         try {
             mWifiManager
                     .getClass()
                     .getDeclaredMethod("enableVerboseLogging", int.class)
-                    .invoke(mWifiManager, enabled ? 1 : 0);
-        } catch (NoSuchMethodException | InvocationTargetException e) {
+                    .invoke(mWifiManager, enable ? 1 : 0);
+        } catch (InvocationTargetException e) {
             throw e.getCause();
         }
     }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -226,14 +226,7 @@ public class WifiManagerSnippet implements Snippet {
     @TargetApi(21)
     @Rpc(description = "Enable or disable wifi verbose logging.")
     public void setWifiVerboseLogging(boolean enable) throws Throwable {
-        try {
-            mWifiManager
-                    .getClass()
-                    .getDeclaredMethod("enableVerboseLogging", int.class)
-                    .invoke(mWifiManager, enable ? 1 : 0);
-        } catch (InvocationTargetException e) {
-            throw e.getCause();
-        }
+        Utils.invokeByReflection(mWifiManager, "enableVerboseLogging", enable ? 1 : 0);
     }
 
     @Rpc(


### PR DESCRIPTION
Added an RPC to enable or disable wifi-verbose logging. Only available on API 21+.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/46)
<!-- Reviewable:end -->
