### PR TITLE
Increasing btDisoverAndGetResults timeout to 2 minutes

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothAdapterSnippet.java
@@ -129,9 +129,9 @@ public class BluetoothAdapterSnippet implements Snippet {
                 throw new BluetoothAdapterSnippetException(
                         "Failed to initiate Bluetooth Discovery.");
             }
-            if (!Utils.waitUntil(() -> mIsScanResultAvailable, 60)) {
+            if (!Utils.waitUntil(() -> mIsScanResultAvailable, 120)) {
                 throw new BluetoothAdapterSnippetException(
-                        "Failed to get discovery results after 1 min, timeout!");
+                        "Failed to get discovery results after 2 mins, timeout!");
             }
         } finally {
             mContext.unregisterReceiver(receiver);


### PR DESCRIPTION
btDiscoverAndGetResults() is flaky when set to only wait up to 1 minute for BT scan results.

It often failed with the following exception:
com.google.android.mobly.snippet.bundled.BluetoothAdapterSnippet$BluetoothAdapterSnippetException: Failed to get discovery results after 1 min, timeout!

Increasing the discovery timeout to 2 mins (a BT standard) should fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/49)
<!-- Reviewable:end -->
