### PR TITLE
Adding BT RPC getAddress

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothAdapterSnippet.java
@@ -108,6 +108,11 @@ public class BluetoothAdapterSnippet implements Snippet {
         return mBluetoothAdapter.getName();
     }
 
+    @Rpc(description = "Returns the hardware address of the local Bluetooth adapter.")
+    public String btGetAddress() {
+        return mBluetoothAdapter.getAddress();
+    }
+
     @Rpc(
         description =
                 "Start discovery, wait for discovery to complete, and return results, which is a list of "

--- a/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothAdapterSnippet.java
@@ -129,9 +129,9 @@ public class BluetoothAdapterSnippet implements Snippet {
                 throw new BluetoothAdapterSnippetException(
                         "Failed to initiate Bluetooth Discovery.");
             }
-            if (!Utils.waitUntil(() -> mIsScanResultAvailable, 60)) {
+            if (!Utils.waitUntil(() -> mIsScanResultAvailable, 120)) {
                 throw new BluetoothAdapterSnippetException(
-                        "Failed to get discovery results after 1 min, timeout!");
+                        "Failed to get discovery results after 2 mins, timeout!");
             }
         } finally {
             mContext.unregisterReceiver(receiver);


### PR DESCRIPTION
This is helpful for validating successful pairing when used in conjunction with  btGetPairedDevices()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/50)
<!-- Reviewable:end -->
