### PR TITLE
Added support for Unknown BT device type

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
@@ -32,6 +32,7 @@ public class MbsEnums {
         return builder.add("DEVICE_TYPE_CLASSIC", BluetoothDevice.DEVICE_TYPE_CLASSIC)
                 .add("DEVICE_TYPE_LE", BluetoothDevice.DEVICE_TYPE_LE)
                 .add("DEVICE_TYPE_DUAL", BluetoothDevice.DEVICE_TYPE_DUAL)
+                .add("DEVICE_TYPE_UNKNOWN", BluetoothDevice.DEVICE_TYPE_UNKNOWN)
                 .build();
     }
 


### PR DESCRIPTION
This prevents btDiscoverAndGetResults() from failing during the serialization steps when there are "unknown" BT devices present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/63)
<!-- Reviewable:end -->
