### PR TITLE
Added getTelephonyServiceState() to TelephonySnippet

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -17,10 +17,12 @@
 package com.google.android.mobly.snippet.bundled;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.telephony.TelephonyManager;
 import com.google.android.mobly.snippet.Snippet;
 import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.rpc.RpcMinSdk;
 
 /** Snippet class for telephony RPCs. */
 public class TelephonySnippet implements Snippet {
@@ -51,14 +53,12 @@ public class TelephonySnippet implements Snippet {
         return mTelephonyManager.getCallState();
     }
 
-    @Rpc(
-        description =
-                "Returns the current Service State information. Service state values are "
-                        + "0: STATE_IN_SERVICE, "
-                        + "1: STATE_OUT_OF_SERVICE, "
-                        + "2: STATE_EMERGENCY_ONLY, "
-                        + "3: STATE_POWER_OFF"
-    )
+    /**
+     * @see <a href="https://developer.android.com/reference/android/telephony/ServiceState.html">
+     *     Service States</a>
+     */
+    @Rpc(description = "Returns the current Service State information")
+    @RpcMinSdk(Build.VERSION_CODES.O)
     public int getTelephonyServiceState() {
         return mTelephonyManager.getServiceState().getState();
     }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -51,6 +51,18 @@ public class TelephonySnippet implements Snippet {
         return mTelephonyManager.getCallState();
     }
 
+    @Rpc(
+        description =
+                "Returns the current Service State information. Service state values are "
+                        + "0: STATE_IN_SERVICE, "
+                        + "1: STATE_OUT_OF_SERVICE, "
+                        + "2: STATE_EMERGENCY_ONLY, "
+                        + "3: STATE_POWER_OFF"
+    )
+    public int getTelephonyServiceState() {
+        return mTelephonyManager.getServiceState().getState();
+    }
+
     @Override
     public void shutdown() {}
 }


### PR DESCRIPTION
Added capability is intended to replace an existing service state that uses output from dumpsys telephony.registry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/77)
<!-- Reviewable:end -->
