### PR TITLE
Add a networking snippet module.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
                            com.google.android.mobly.snippet.bundled.MediaSnippet,
                            com.google.android.mobly.snippet.bundled.NotificationSnippet,
                            com.google.android.mobly.snippet.bundled.TelephonySnippet,
+                           com.google.android.mobly.snippet.bundled.NetworkingSnippet,
                            com.google.android.mobly.snippet.bundled.SmsSnippet,
                            com.google.android.mobly.snippet.bundled.WifiManagerSnippet" />
     </application>

--- a/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
@@ -22,19 +22,18 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import com.google.android.mobly.snippet.Snippet;
 import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.util.Log;
 
 /** Snippet class for networking RPCs. */
 public class NetworkingSnippet implements Snippet {
 
-    public NetworkingSnippet() {
-    }
-
     @Rpc(description = "Check if a host and port are connectable using a TCP connection attempt.")
-    public boolean Connectable(String host, int port) {
+    public boolean isTcpConnectable(String host, int port) {
         InetAddress addr;
         try {
             addr = InetAddress.getByName(host);
         } catch (UnknownHostException uherr) {
+            Log.d("Host name lookup failure: " + uherr.getMessage());
             return false;
         }
 
@@ -42,9 +41,9 @@ public class NetworkingSnippet implements Snippet {
             Socket sock = new Socket(addr, port);
             sock.close();
         } catch (IOException ioerr) {
+            Log.d("Did not make connection to host: " + ioerr.getMessage());
             return false;
         }
-
         return true;
     }
 

--- a/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.bundled;
+
+import java.net.InetAddress;
+import java.net.Socket;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.rpc.Rpc;
+
+/** Snippet class for networking RPCs. */
+public class NetworkingSnippet implements Snippet {
+
+    public NetworkingSnippet() {
+    }
+
+    @Rpc(description = "Check if a host and port are connectable using a TCP connection attempt.")
+    public boolean Connectable(String host, int port) {
+        InetAddress addr;
+        try {
+            addr = InetAddress.getByName(host);
+        } catch (UnknownHostException uherr) {
+            return false;
+        }
+
+        try {
+            Socket sock = new Socket(addr, port);
+            sock.close();
+        } catch (IOException ioerr) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
@@ -28,7 +28,7 @@ import com.google.android.mobly.snippet.util.Log;
 public class NetworkingSnippet implements Snippet {
 
     @Rpc(description = "Check if a host and port are connectable using a TCP connection attempt.")
-    public boolean isTcpConnectable(String host, int port) {
+    public boolean networkIsTcpConnectable(String host, int port) {
         InetAddress addr;
         try {
             addr = InetAddress.getByName(host);


### PR DESCRIPTION
Has one method for now, Connectable, that implicitly checks TCP
connectivity to a host and port.

Example usage using snippet_shell:

```
$ snippet_shell -s HTxxxxxxxx  com.google.android.mobly.snippet.bundled
# (after first installation)
>>> s.networkIsTcpConnectable("www.google.com", 80)
False
# After network setup
>>> s.networkIsTcpConnectable("www.google.com", 80)
True

>>> start = datetime.now() ; s.networkIsTcpConnectable("www.google.com", 81) ; print(datetime.now() - start)
False
0:02:07.438771

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/78)
<!-- Reviewable:end -->
