### PR TITLE
Method to perform HTTP download to local storage.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
                            com.google.android.mobly.snippet.bundled.NotificationSnippet,
                            com.google.android.mobly.snippet.bundled.TelephonySnippet,
                            com.google.android.mobly.snippet.bundled.NetworkingSnippet,
+                           com.google.android.mobly.snippet.bundled.FileSnippet,
                            com.google.android.mobly.snippet.bundled.SmsSnippet,
                            com.google.android.mobly.snippet.bundled.WifiManagerSnippet" />
     </application>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
@@ -64,11 +64,10 @@ public class FileSnippet implements Snippet {
         }
     }
 
-    @Rpc(description = "Remove a file pointed to by the content URI. Return "
-            + "number deleted (should always be one)")
-    public int fileDeleteContent(String uri) {
+    @Rpc(description = "Remove a file pointed to by the content URI.")
+    public void fileDeleteContent(String uri) {
         Uri uri_ = Uri.parse(uri);
-        return mContext.getContentResolver().delete(uri_, null, null);
+        mContext.getContentResolver().delete(uri_, null, null);
     }
 
     @Override

--- a/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
@@ -27,7 +27,6 @@ import android.support.test.InstrumentationRegistry;
 import com.google.android.mobly.snippet.Snippet;
 import com.google.android.mobly.snippet.bundled.utils.Utils;
 import com.google.android.mobly.snippet.rpc.Rpc;
-import com.google.android.mobly.snippet.util.Log;
 
 /** Snippet class for File and abstract storage URI operation RPCs. */
 public class FileSnippet implements Snippet {

--- a/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.bundled;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.DigestInputStream;
+import java.security.NoSuchAlgorithmException;
+import android.content.Context;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.support.test.InstrumentationRegistry;
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.bundled.utils.Utils;
+import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.util.Log;
+
+/** Snippet class for File and abstract storage URI operation RPCs. */
+public class FileSnippet implements Snippet {
+
+    private final Context mContext;
+
+    public FileSnippet() {
+        mContext = InstrumentationRegistry.getContext();
+    }
+
+    private static class FileSnippetException extends Exception {
+
+        private static final long serialVersionUID = 8081L;
+
+        public FileSnippetException(String msg) {
+            super(msg);
+        }
+    }
+
+    @Rpc(description = "Compute MD5 hash on a content URI. Return the MD5 has has a hex string.")
+    public String fileMd5Hash(String uri) throws IOException, NoSuchAlgorithmException  {
+        Uri uri_ = Uri.parse(uri);
+        ParcelFileDescriptor pfd = mContext.getContentResolver().openFileDescriptor(uri_, "r");
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        int length = (int) pfd.getStatSize();
+        byte[] buf = new byte[length];
+        ParcelFileDescriptor.AutoCloseInputStream stream = new ParcelFileDescriptor.AutoCloseInputStream(pfd);
+        DigestInputStream dis = new DigestInputStream(stream, md);
+        try {
+            dis.read(buf, 0, length);
+            return Utils.bytesToHexString(md.digest());
+        } finally {
+            dis.close();
+            stream.close();
+        }
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/FileSnippet.java
@@ -64,6 +64,13 @@ public class FileSnippet implements Snippet {
         }
     }
 
+    @Rpc(description = "Remove a file pointed to by the content URI. Return "
+            + "number deleted (should always be one)")
+    public int fileDeleteContent(String uri) {
+        Uri uri_ = Uri.parse(uri);
+        return mContext.getContentResolver().delete(uri_, null, null);
+    }
+
     @Override
     public void shutdown() {}
 }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
@@ -20,12 +20,30 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.BroadcastReceiver;
+import android.net.Uri;
+import android.os.Environment;
+import android.app.DownloadManager;
+import android.support.test.InstrumentationRegistry;
 import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.bundled.utils.Utils;
 import com.google.android.mobly.snippet.rpc.Rpc;
 import com.google.android.mobly.snippet.util.Log;
 
 /** Snippet class for networking RPCs. */
 public class NetworkingSnippet implements Snippet {
+
+    private final DownloadManager mDownloadManager;
+    private final Context mContext;
+    private volatile boolean mIsDownloadComplete = false;
+
+    public NetworkingSnippet() {
+        mContext = InstrumentationRegistry.getContext();
+        mDownloadManager = (DownloadManager) mContext.getSystemService(Context.DOWNLOAD_SERVICE);
+    }
 
     @Rpc(description = "Check if a host and port are connectable using a TCP connection attempt.")
     public boolean networkIsTcpConnectable(String host, int port) {
@@ -45,6 +63,46 @@ public class NetworkingSnippet implements Snippet {
             return false;
         }
         return true;
+    }
+
+    @Rpc(description = "Download a file using HTTP.")
+    public String networkHTTPDownload(String url, String destination) {
+        long reqid = 0;
+        Uri uri = Uri.parse(url);
+        DownloadManager.Request request = new DownloadManager.Request(uri);
+        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, destination);
+        mIsDownloadComplete = false;
+        IntentFilter filter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
+        BroadcastReceiver receiver = new DownloadReceiver();
+        mContext.registerReceiver(receiver, filter);
+        try {
+            reqid = mDownloadManager.enqueue(request);
+            Log.d(String.format("networkHTTPDownload download of %s with id %d", url, reqid));
+            if (!Utils.waitUntil(() -> mIsDownloadComplete, 240)) {
+                return "";
+            }
+        } finally {
+            mContext.unregisterReceiver(receiver);
+        }
+
+        Uri resp = mDownloadManager.getUriForDownloadedFile(reqid);
+        if (resp != null) {
+            Log.d(String.format("networkHTTPDownload completed to %s", resp.toString()));
+            return resp.toString();
+        } else {
+            return "";
+        }
+    }
+
+    private class DownloadReceiver extends BroadcastReceiver {
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            if (DownloadManager.ACTION_DOWNLOAD_COMPLETE.equals(action)) {
+                mIsDownloadComplete = true;
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
@@ -107,6 +107,7 @@ public class NetworkingSnippet implements Snippet {
         Uri resp = mDownloadManager.getUriForDownloadedFile(mReqid);
         if (resp != null) {
             Log.d(String.format("networkHttpDownload completed to %s", resp.toString()));
+            mReqid = 0;
             return resp.toString();
         } else {
             Log.d(String.format("networkHttpDownload Failed to download %s", uri.toString()));
@@ -128,5 +129,9 @@ public class NetworkingSnippet implements Snippet {
     }
 
     @Override
-    public void shutdown() {}
+    public void shutdown() {
+        if (mReqid != 0) {
+            mDownloadManager.remove(mReqid);
+        }
+    }
 }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
@@ -21,9 +21,6 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.security.MessageDigest;
-import java.security.DigestInputStream;
-import java.security.NoSuchAlgorithmException;
 import android.content.Intent;
 import android.content.Context;
 import android.content.IntentFilter;
@@ -82,7 +79,7 @@ public class NetworkingSnippet implements Snippet {
 
     @Rpc(description = "Download a file using HTTP. Return content Uri (file remains on device). "
                        + "The Uri should be treated as an opaque handle for further operations.")
-    public String networkHTTPDownload(String url) throws IllegalArgumentException, NetworkingSnippetException {
+    public String networkHttpDownload(String url) throws IllegalArgumentException, NetworkingSnippetException {
 
         Uri uri = Uri.parse(url);
         List<String> pathsegments = uri.getPathSegments();
@@ -115,27 +112,6 @@ public class NetworkingSnippet implements Snippet {
             Log.d(String.format("networkHTTPDownload Failed to download %s", uri.toString()));
             throw new NetworkingSnippetException("networkHTTPDownload didn't get downloaded file.");
         }
-    }
-
-    @Rpc(description = "Compute MD5 hash on a content URI. Return the MD5 has has a hex string.")
-    public String networkMD5Hash(String uri) throws IOException, NoSuchAlgorithmException  {
-        String md5string = "";
-
-        Uri uri_ = Uri.parse(uri);
-        ParcelFileDescriptor pfd = mContext.getContentResolver().openFileDescriptor(uri_, "r");
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        int length = (int) pfd.getStatSize();
-        byte[] buf = new byte[length];
-        ParcelFileDescriptor.AutoCloseInputStream stream = new ParcelFileDescriptor.AutoCloseInputStream(pfd);
-        DigestInputStream dis = new DigestInputStream(stream, md);
-        try {
-            dis.read(buf, 0, length);
-            md5string = Utils.bytesToHexString(md.digest());
-        } finally {
-            dis.close();
-            stream.close();
-        }
-        return md5string;
     }
 
     private class DownloadReceiver extends BroadcastReceiver {

--- a/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/NetworkingSnippet.java
@@ -96,21 +96,21 @@ public class NetworkingSnippet implements Snippet {
         mContext.registerReceiver(receiver, filter);
         try {
             mReqid = mDownloadManager.enqueue(request);
-            Log.d(String.format("networkHTTPDownload download of %s with id %d", url, mReqid));
+            Log.d(String.format("networkHttpDownload download of %s with id %d", url, mReqid));
             if (!Utils.waitUntil(() -> mIsDownloadComplete, 30)) {
-                Log.d(String.format("networkHTTPDownload timed out waiting for completion"));
-                throw new NetworkingSnippetException("networkHTTPDownload timed out.");
+                Log.d(String.format("networkHttpDownload timed out waiting for completion"));
+                throw new NetworkingSnippetException("networkHttpDownload timed out.");
             }
         } finally {
             mContext.unregisterReceiver(receiver);
         }
         Uri resp = mDownloadManager.getUriForDownloadedFile(mReqid);
         if (resp != null) {
-            Log.d(String.format("networkHTTPDownload completed to %s", resp.toString()));
+            Log.d(String.format("networkHttpDownload completed to %s", resp.toString()));
             return resp.toString();
         } else {
-            Log.d(String.format("networkHTTPDownload Failed to download %s", uri.toString()));
-            throw new NetworkingSnippetException("networkHTTPDownload didn't get downloaded file.");
+            Log.d(String.format("networkHttpDownload Failed to download %s", uri.toString()));
+            throw new NetworkingSnippetException("networkHttpDownload didn't get downloaded file.");
         }
     }
 

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
@@ -202,7 +202,7 @@ public final class Utils {
      * @param bytes The array of byte to convert.
      * @return a String with the ASCII hex representation.
      */
-    public static String bytesToHex(byte[] bytes) {
+    public static String bytesToHexString(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];
         for ( int j = 0; j < bytes.length; j++ ) {
             int v = bytes[j] & 0xFF;

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeoutException;
 
 public final class Utils {
 
+    private final static char[] hexArray = "0123456789abcdef".toCharArray();
+
     private Utils() {}
 
     /**
@@ -190,4 +192,24 @@ public final class Utils {
             throw e.getCause();
         }
     }
+
+    /**
+     * Convert a byte array (binary data) to a hexadecimal string (ASCII)
+     * representation.
+
+     * [\x01\x02] -&gt; "0102"
+     *
+     * @param bytes The array of byte to convert.
+     * @return a String with the ASCII hex representation.
+     */
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
 }


### PR DESCRIPTION
Use Android API to download file using HTTP and store locally. Locally compute MD5 hash and  respond to host with Uri and hash value.

Since current usage of curl does not make use of the downloaded file other than to compute the MD5 hash to, presumably, verify transfer integrity it's not necessary to copy the file to the host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/80)
<!-- Reviewable:end -->
