### PR TITLE
Fix a missing value in BleAdvertisingTxPower enum.

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonSerializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonSerializer.java
@@ -185,9 +185,7 @@ public class JsonSerializer {
     private Bundle serializeBleScanRecord(ScanRecord record) {
         Bundle result = new Bundle();
         result.putString("DeviceName", record.getDeviceName());
-        result.putString(
-                "TxPowerLevel",
-                MbsEnums.BLE_ADVERTISE_TX_POWER.getString(record.getTxPowerLevel()));
+        result.putInt("TxPowerLevel", record.getTxPowerLevel());
         return result;
     }
 

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
@@ -47,7 +47,6 @@ public class MbsEnums {
                 .add("ADVERTISE_TX_POWER_LOW", AdvertiseSettings.ADVERTISE_TX_POWER_LOW)
                 .add("ADVERTISE_TX_POWER_MEDIUM", AdvertiseSettings.ADVERTISE_TX_POWER_MEDIUM)
                 .add("ADVERTISE_TX_POWER_HIGH", AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
-                .add("ADVERTISE_TX_POWER_HIGH", AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
                 .add("ADVERTISE_TX_POWER_NOT_SET", Integer.MIN_VALUE)
                 .build();
     }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
@@ -47,6 +47,8 @@ public class MbsEnums {
                 .add("ADVERTISE_TX_POWER_LOW", AdvertiseSettings.ADVERTISE_TX_POWER_LOW)
                 .add("ADVERTISE_TX_POWER_MEDIUM", AdvertiseSettings.ADVERTISE_TX_POWER_MEDIUM)
                 .add("ADVERTISE_TX_POWER_HIGH", AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+                .add("ADVERTISE_TX_POWER_HIGH", AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+                .add("ADVERTISE_TX_POWER_NOT_SET", Integer.MIN_VALUE)
                 .build();
     }
 

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
@@ -47,7 +47,6 @@ public class MbsEnums {
                 .add("ADVERTISE_TX_POWER_LOW", AdvertiseSettings.ADVERTISE_TX_POWER_LOW)
                 .add("ADVERTISE_TX_POWER_MEDIUM", AdvertiseSettings.ADVERTISE_TX_POWER_MEDIUM)
                 .add("ADVERTISE_TX_POWER_HIGH", AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
-                .add("ADVERTISE_TX_POWER_NOT_SET", Integer.MIN_VALUE)
                 .build();
     }
 


### PR DESCRIPTION
Turns out the TxPower level field in scan record is a `db` value instead of TxPower enum.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/86)
<!-- Reviewable:end -->
