### PR TITLE
Handle a race condition in wifi/bt toggle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,12 +77,12 @@ dependencies {
     compile 'com.android.support.test:runner:0.5'
     compile 'com.google.android.mobly:mobly-snippet-lib:1.2.0'
     compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.google.guava:guava:23.1-android'
-    compile 'com.google.errorprone:error_prone_annotations:2.1.1'
+    compile 'com.google.guava:guava:23.4-android'
+    compile 'com.google.errorprone:error_prone_annotations:2.1.3'
 
-    testCompile 'com.google.errorprone:error_prone_annotations:2.1.1'
-    testCompile 'com.google.guava:guava:23.1-android'
-    testCompile 'com.google.truth:truth:0.36'
+    testCompile 'com.google.errorprone:error_prone_annotations:2.1.3'
+    testCompile 'com.google.guava:guava:23.4-android'
+    testCompile 'com.google.truth:truth:0.37'
     testCompile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
E.g. if BT was in the process of turning off when we called `btEnable`,
BT would finish turning off before turning on again, but the `btEnable`
call would timeout before that.

Same situation for `btDisable` and wifi toggles.

Also update gradle deps per presubmit requirements.

@k2fong @kdart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/91)
<!-- Reviewable:end -->
