### PR TITLE
Handle Wi-Fi permission requirements in Q.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // NOTE: Do not place your application dependencies here.
     }
@@ -32,11 +32,11 @@ allprojects {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
-        minSdkVersion 15
+        minSdkVersion 18
         // Set target to 22 to avoid having to deal with runtime permissions.
         targetSdkVersion 22
         versionCode 1
@@ -74,7 +74,7 @@ artifacts {
 }
 
 dependencies {
-    implementation 'androidx.test:runner:1.1.1'
+    implementation 'androidx.test:runner:1.2.0'
     implementation 'com.google.android.mobly:mobly-snippet-lib:1.2.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.google.guava:guava:27.0.1-android'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
-        minSdkVersion 18
+        minSdkVersion 15
         // Set target to 22 to avoid having to deal with runtime permissions.
         targetSdkVersion 22
         versionCode 1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 10 15:04:39 PST 2019
+#Tue Jun 11 17:51:34 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <application android:allowBackup="false"
-                 android:name="android.support.multidex.MultiDexApplication">
+                 android:name="androidx.multidex.MultiDexApplication">
         <meta-data
             android:name="mobly-snippets"
             android:value="com.google.android.mobly.snippet.bundled.AccountSnippet,

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
     <uses-permission android:name="android.permission.READ_SMS" />

--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -62,6 +62,11 @@ public class WifiManagerSnippet implements Snippet {
         mWifiManager =
                 (WifiManager)
                         mContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+        if (Build.VERSION.SDK_INT >= 29) {
+            InstrumentationRegistry.getInstrumentation()
+                    .getUiAutomation()
+                    .adoptShellPermissionIdentity();
+        }
     }
 
     @Rpc(


### PR DESCRIPTION
* Adopt shell permission in Wi-Fi snippet when it's Q.
* Fix ClassNotFound error caused by androidx

Tested locally and confirmed that the change works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/111)
<!-- Reviewable:end -->
