### PR TITLE
Cleanup UiAutomator connection

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -69,7 +69,7 @@ public class WifiManagerSnippet implements Snippet {
         mWifiManager =
                 (WifiManager)
                         mContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        if (Build.VERSION.SDK_INT >= 29) {
+        if (mContext.getApplicationContext().getApplicationInfo().targetSdkVersion >= 29) {
             UiAutomation uia = InstrumentationRegistry.getInstrumentation().getUiAutomation();
             uia.adoptShellPermissionIdentity();
             try {
@@ -77,10 +77,10 @@ public class WifiManagerSnippet implements Snippet {
                 Method destroyMethod = cls.getDeclaredMethod("destroy");
                 destroyMethod.invoke(uia);
             } catch (NoSuchMethodException
-                  | IllegalAccessException
-                  | ClassNotFoundException
-                  | InvocationTargetException e) {
-                      throw new WifiManagerSnippetException("Failed to cleaup Ui Automation", e);
+                    | IllegalAccessException
+                    | ClassNotFoundException
+                    | InvocationTargetException e) {
+                throw new WifiManagerSnippetException("Failed to cleaup Ui Automation", e);
             }
         }
     }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -69,7 +69,7 @@ public class WifiManagerSnippet implements Snippet {
         mWifiManager =
                 (WifiManager)
                         mContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        elevatePermissionIfRequired();
+        adaptShellPermissionIfRequired();
     }
 
     @Rpc(
@@ -395,12 +395,13 @@ public class WifiManagerSnippet implements Snippet {
     /**
      * Elevates permission as require for proper wifi controls.
      *
+     * Starting in Android Q (29), additional restrictions are added for wifi operation. See
+     * below Android Q privacy changes for additional details.
+     * https://developer.android.com/preview/privacy/camera-connectivity
+     *
      * @throws Throwable
      */
-    private void elevatePermissionIfRequired() throws Throwable {
-        // Starting in Android Q (29), additional restrictions are added for wifi operation. See
-        // below Android Q privacy changes for additional details.
-        // https://developer.android.com/preview/privacy/camera-connectivity
+    private void adaptShellPermissionIfRequired() throws Throwable {
         if (mContext.getApplicationContext().getApplicationInfo().targetSdkVersion >= 29
             && Build.VERSION.SDK_INT >= 29) {
           Log.d("Elevating permission require to enable support for wifi operation in Android Q+");


### PR DESCRIPTION
cleanup UiAutomator connection after use.  This will enable other UiAutomator user to properly connect instead of getting an "already registered" exception because UiAutomator only accept a single connection at any giving time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/114)
<!-- Reviewable:end -->
