### PR TITLE
Fix "JavaCodeClarity" problem for BluetoothHearingAidSnippet

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
                            com.google.android.mobly.snippet.bundled.AudioSnippet,
                            com.google.android.mobly.snippet.bundled.bluetooth.BluetoothAdapterSnippet,
                            com.google.android.mobly.snippet.bundled.bluetooth.profiles.BluetoothA2dpSnippet,
+                           com.google.android.mobly.snippet.bundled.bluetooth.profiles.BluetoothHearingAidSnippet,
                            com.google.android.mobly.snippet.bundled.BluetoothLeAdvertiserSnippet,
                            com.google.android.mobly.snippet.bundled.BluetoothLeScannerSnippet,
                            com.google.android.mobly.snippet.bundled.LogSnippet,

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
@@ -28,11 +28,12 @@ public class BluetoothHearingAidSnippet implements Snippet {
         }
     }
 
+    private static final int TIMEOUT_SEC = 60;
+    
     private Context context;
     private static boolean isHearingAidProfileReady = false;
     private static BluetoothHearingAid hearingAidProfile;
     private final JsonSerializer jsonSerializer = new JsonSerializer();
-    private static final int timeoutSeconds = 60;
 
     @TargetApi(Build.VERSION_CODES.Q)
     public BluetoothHearingAidSnippet() {
@@ -40,7 +41,7 @@ public class BluetoothHearingAidSnippet implements Snippet {
         BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         bluetoothAdapter.getProfileProxy(
                 context, new HearingAidServiceListener(), BluetoothProfile.HEARING_AID);
-        Utils.waitUntil(() -> isHearingAidProfileReady, timeoutSeconds);
+        Utils.waitUntil(() -> isHearingAidProfileReady, TIMEOUT_SEC);
     }
 
     @TargetApi(Build.VERSION_CODES.Q)
@@ -67,11 +68,11 @@ public class BluetoothHearingAidSnippet implements Snippet {
                 () ->
                         hearingAidProfile.getConnectionState(device)
                                 == BluetoothHearingAid.STATE_CONNECTED,
-                timeoutSeconds)) {
+                TIMEOUT_SEC)) {
             throw new BluetoothHearingAidSnippetException(
                     String.format(
                             "Failed to connect to device %s|%s with HA profile within %d sec.",
-                            device.getName(), device.getAddress(), timeoutSeconds));
+                            device.getName(), device.getAddress(), TIMEOUT_SEC));
         }
     }
 
@@ -83,11 +84,11 @@ public class BluetoothHearingAidSnippet implements Snippet {
                 () ->
                         hearingAidProfile.getConnectionState(device)
                                 == BluetoothHearingAid.STATE_DISCONNECTED,
-                timeoutSeconds)) {
+                TIMEOUT_SEC)) {
             throw new BluetoothHearingAidSnippetException(
                     String.format(
                             "Failed to disconnect to device %s|%s with HA profile within %d sec.",
-                            device.getName(), device.getAddress(), timeoutSeconds));
+                            device.getName(), device.getAddress(), TIMEOUT_SEC));
         }
     }
 

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
@@ -1,0 +1,116 @@
+package com.google.android.mobly.snippet.bundled.bluetooth.profiles;
+
+import android.annotation.TargetApi;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHearingAid;
+import android.bluetooth.BluetoothProfile;
+import android.content.Context;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.Bundle;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.bundled.bluetooth.BluetoothAdapterSnippet;
+import com.google.android.mobly.snippet.bundled.bluetooth.PairingBroadcastReceiver;
+import com.google.android.mobly.snippet.bundled.utils.JsonSerializer;
+import com.google.android.mobly.snippet.bundled.utils.Utils;
+import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.rpc.RpcMinSdk;
+import java.util.ArrayList;
+
+public class BluetoothHearingAidSnippet implements Snippet {
+    private static class BluetoothHearingAidSnippetException extends Exception {
+        private static final long serialVersionUID = 1;
+
+        BluetoothHearingAidSnippetException(String msg) {
+            super(msg);
+        }
+    }
+
+    private Context context;
+    private static boolean sIsHearingAidProfileReady = false;
+    private static BluetoothHearingAid sHearingAidProfile;
+    private final JsonSerializer mJsonSerializer = new JsonSerializer();
+
+    @TargetApi(Build.VERSION_CODES.Q)
+    public BluetoothHearingAidSnippet() {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        bluetoothAdapter.getProfileProxy(
+                context, new HearingAidServiceListener(), BluetoothProfile.HEARING_AID);
+        Utils.waitUntil(() -> sIsHearingAidProfileReady, 60);
+    }
+
+    @TargetApi(Build.VERSION_CODES.Q)
+    private static class HearingAidServiceListener implements BluetoothProfile.ServiceListener {
+        public void onServiceConnected(int var1, BluetoothProfile profile) {
+            sHearingAidProfile = (BluetoothHearingAid) profile;
+            sIsHearingAidProfileReady = true;
+        }
+
+        public void onServiceDisconnected(int var1) {
+            sIsHearingAidProfileReady = false;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.Q)
+    @RpcMinSdk(Build.VERSION_CODES.Q)
+    @Rpc(description = "Connects to a paired or discovered device with HA profile.")
+    public void btHearingAidConnect(String deviceAddress) throws Throwable {
+        BluetoothDevice device = BluetoothAdapterSnippet.getKnownDeviceByAddress(deviceAddress);
+        IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
+        context.registerReceiver(new PairingBroadcastReceiver(context), filter);
+        Utils.invokeByReflection(sHearingAidProfile, "connect", device);
+        if (!Utils.waitUntil(
+                () ->
+                        sHearingAidProfile.getConnectionState(device)
+                                == BluetoothHearingAid.STATE_CONNECTED,
+                120)) {
+            throw new BluetoothHearingAidSnippetException(
+                    "Failed to connect to device "
+                            + device.getName()
+                            + "|"
+                            + device.getAddress()
+                            + " with HA profile within 2min.");
+        }
+    }
+
+    @Rpc(description = "Disconnects a device from HA profile.")
+    public void btHearingAidDisconnect(String deviceAddress) throws Throwable {
+        BluetoothDevice device = getConnectedBluetoothDevice(deviceAddress);
+        Utils.invokeByReflection(sHearingAidProfile, "disconnect", device);
+        if (!Utils.waitUntil(
+                () ->
+                        sHearingAidProfile.getConnectionState(device)
+                                == BluetoothHearingAid.STATE_DISCONNECTED,
+                120)) {
+            throw new BluetoothHearingAidSnippetException(
+                    "Failed to disconnect device "
+                            + device.getName()
+                            + "|"
+                            + device.getAddress()
+                            + " from HA profile within 2min.");
+        }
+    }
+
+    @Rpc(description = "Gets all the devices currently connected via HA profile.")
+    public ArrayList<Bundle> btHearingAidGetConnectedDevices() {
+        return mJsonSerializer.serializeBluetoothDeviceList(
+                sHearingAidProfile.getConnectedDevices());
+    }
+
+    private BluetoothDevice getConnectedBluetoothDevice(String deviceAddress)
+            throws BluetoothHearingAidSnippetException {
+        for (BluetoothDevice device : sHearingAidProfile.getConnectedDevices()) {
+            if (device.getAddress().equalsIgnoreCase(deviceAddress)) {
+                return device;
+            }
+        }
+        throw new BluetoothHearingAidSnippetException(
+                "No device with address " + deviceAddress + " is connected via HA Profile.");
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
@@ -17,6 +17,7 @@ import com.google.android.mobly.snippet.bundled.utils.JsonSerializer;
 import com.google.android.mobly.snippet.bundled.utils.Utils;
 import com.google.android.mobly.snippet.rpc.Rpc;
 import com.google.android.mobly.snippet.rpc.RpcMinSdk;
+import com.google.common.base.Ascii;
 import java.util.ArrayList;
 
 public class BluetoothHearingAidSnippet implements Snippet {
@@ -29,8 +30,8 @@ public class BluetoothHearingAidSnippet implements Snippet {
     }
 
     private static final int TIMEOUT_SEC = 60;
-    
-    private Context context;
+
+    private final Context context;
     private static boolean isHearingAidProfileReady = false;
     private static BluetoothHearingAid hearingAidProfile;
     private final JsonSerializer jsonSerializer = new JsonSerializer();
@@ -46,11 +47,13 @@ public class BluetoothHearingAidSnippet implements Snippet {
 
     @TargetApi(Build.VERSION_CODES.Q)
     private static class HearingAidServiceListener implements BluetoothProfile.ServiceListener {
+        @Override
         public void onServiceConnected(int var1, BluetoothProfile profile) {
             hearingAidProfile = (BluetoothHearingAid) profile;
             isHearingAidProfileReady = true;
         }
 
+        @Override
         public void onServiceDisconnected(int var1) {
             isHearingAidProfileReady = false;
         }
@@ -97,15 +100,16 @@ public class BluetoothHearingAidSnippet implements Snippet {
         return jsonSerializer.serializeBluetoothDeviceList(hearingAidProfile.getConnectedDevices());
     }
 
-    private BluetoothDevice getConnectedBluetoothDevice(String deviceAddress)
+    private static BluetoothDevice getConnectedBluetoothDevice(String deviceAddress)
             throws BluetoothHearingAidSnippetException {
         for (BluetoothDevice device : hearingAidProfile.getConnectedDevices()) {
-            if (device.getAddress().equalsIgnoreCase(deviceAddress)) {
+            if (Ascii.equalsIgnoreCase(device.getAddress(), deviceAddress)) {
                 return device;
             }
         }
-        throw new BluetoothHearingAidSnippetException(String.format(
-                "No device with address %s is connected via HA Profile.", deviceAddress));
+        throw new BluetoothHearingAidSnippetException(
+                String.format(
+                        "No device with address %s is connected via HA Profile.", deviceAddress));
     }
 
     @Override

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
@@ -28,17 +28,17 @@ public class BluetoothHearingAidSnippet implements Snippet {
         }
     }
 
-    private Context context;
+    private Context mContext;
     private static boolean sIsHearingAidProfileReady = false;
     private static BluetoothHearingAid sHearingAidProfile;
     private final JsonSerializer mJsonSerializer = new JsonSerializer();
 
     @TargetApi(Build.VERSION_CODES.Q)
     public BluetoothHearingAidSnippet() {
-        context = InstrumentationRegistry.getInstrumentation().getContext();
+        mContext = InstrumentationRegistry.getInstrumentation().getContext();
         BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         bluetoothAdapter.getProfileProxy(
-                context, new HearingAidServiceListener(), BluetoothProfile.HEARING_AID);
+                mContext, new HearingAidServiceListener(), BluetoothProfile.HEARING_AID);
         Utils.waitUntil(() -> sIsHearingAidProfileReady, 60);
     }
 
@@ -60,7 +60,7 @@ public class BluetoothHearingAidSnippet implements Snippet {
     public void btHearingAidConnect(String deviceAddress) throws Throwable {
         BluetoothDevice device = BluetoothAdapterSnippet.getKnownDeviceByAddress(deviceAddress);
         IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
-        context.registerReceiver(new PairingBroadcastReceiver(context), filter);
+        mContext.registerReceiver(new PairingBroadcastReceiver(mContext), filter);
         Utils.invokeByReflection(sHearingAidProfile, "connect", device);
         if (!Utils.waitUntil(
                 () ->

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
@@ -32,6 +32,7 @@ public class BluetoothHearingAidSnippet implements Snippet {
     private static boolean isHearingAidProfileReady = false;
     private static BluetoothHearingAid hearingAidProfile;
     private final JsonSerializer jsonSerializer = new JsonSerializer();
+    private static final int timeoutSeconds = 60;
 
     @TargetApi(Build.VERSION_CODES.Q)
     public BluetoothHearingAidSnippet() {
@@ -39,7 +40,7 @@ public class BluetoothHearingAidSnippet implements Snippet {
         BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         bluetoothAdapter.getProfileProxy(
                 context, new HearingAidServiceListener(), BluetoothProfile.HEARING_AID);
-        Utils.waitUntil(() -> isHearingAidProfileReady, 60);
+        Utils.waitUntil(() -> isHearingAidProfileReady, timeoutSeconds);
     }
 
     @TargetApi(Build.VERSION_CODES.Q)
@@ -66,13 +67,11 @@ public class BluetoothHearingAidSnippet implements Snippet {
                 () ->
                         hearingAidProfile.getConnectionState(device)
                                 == BluetoothHearingAid.STATE_CONNECTED,
-                120)) {
+                timeoutSeconds)) {
             throw new BluetoothHearingAidSnippetException(
-                    "Failed to connect to device "
-                            + device.getName()
-                            + "|"
-                            + device.getAddress()
-                            + " with HA profile within 2min.");
+                    String.format(
+                            "Failed to connect to device %s|%s with HA profile within %d sec.",
+                            device.getName(), device.getAddress(), timeoutSeconds));
         }
     }
 
@@ -84,20 +83,17 @@ public class BluetoothHearingAidSnippet implements Snippet {
                 () ->
                         hearingAidProfile.getConnectionState(device)
                                 == BluetoothHearingAid.STATE_DISCONNECTED,
-                120)) {
+                timeoutSeconds)) {
             throw new BluetoothHearingAidSnippetException(
-                    "Failed to disconnect device "
-                            + device.getName()
-                            + "|"
-                            + device.getAddress()
-                            + " from HA profile within 2min.");
+                    String.format(
+                            "Failed to disconnect to device %s|%s with HA profile within %d sec.",
+                            device.getName(), device.getAddress(), timeoutSeconds));
         }
     }
 
     @Rpc(description = "Gets all the devices currently connected via HA profile.")
     public ArrayList<Bundle> btHearingAidGetConnectedDevices() {
-        return jsonSerializer.serializeBluetoothDeviceList(
-                hearingAidProfile.getConnectedDevices());
+        return jsonSerializer.serializeBluetoothDeviceList(hearingAidProfile.getConnectedDevices());
     }
 
     private BluetoothDevice getConnectedBluetoothDevice(String deviceAddress)
@@ -107,8 +103,8 @@ public class BluetoothHearingAidSnippet implements Snippet {
                 return device;
             }
         }
-        throw new BluetoothHearingAidSnippetException(
-                "No device with address " + deviceAddress + " is connected via HA Profile.");
+        throw new BluetoothHearingAidSnippetException(String.format(
+                "No device with address %s is connected via HA Profile.", deviceAddress));
     }
 
     @Override

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothHearingAidSnippet.java
@@ -28,17 +28,17 @@ public class BluetoothHearingAidSnippet implements Snippet {
         }
     }
 
-    private Context mContext;
+    private Context context;
     private static boolean sIsHearingAidProfileReady = false;
     private static BluetoothHearingAid sHearingAidProfile;
     private final JsonSerializer mJsonSerializer = new JsonSerializer();
 
     @TargetApi(Build.VERSION_CODES.Q)
     public BluetoothHearingAidSnippet() {
-        mContext = InstrumentationRegistry.getInstrumentation().getContext();
+        context = InstrumentationRegistry.getInstrumentation().getContext();
         BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         bluetoothAdapter.getProfileProxy(
-                mContext, new HearingAidServiceListener(), BluetoothProfile.HEARING_AID);
+                context, new HearingAidServiceListener(), BluetoothProfile.HEARING_AID);
         Utils.waitUntil(() -> sIsHearingAidProfileReady, 60);
     }
 
@@ -60,7 +60,7 @@ public class BluetoothHearingAidSnippet implements Snippet {
     public void btHearingAidConnect(String deviceAddress) throws Throwable {
         BluetoothDevice device = BluetoothAdapterSnippet.getKnownDeviceByAddress(deviceAddress);
         IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_PAIRING_REQUEST);
-        mContext.registerReceiver(new PairingBroadcastReceiver(mContext), filter);
+        context.registerReceiver(new PairingBroadcastReceiver(context), filter);
         Utils.invokeByReflection(sHearingAidProfile, "connect", device);
         if (!Utils.waitUntil(
                 () ->


### PR DESCRIPTION
line 100: A private method that does not reference the enclosing instance can be static
line 33: This field is only assigned during initialization; consider making it final
line 103: JDK case-related methods depend dangerously on the implicit default locale
line 49: onServiceConnected implements method in ServiceListener; expected @override
line 54: onServiceDisconnected implements method in ServiceListener; expected @override

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/120)
<!-- Reviewable:end -->
