### PR TITLE
Add a Rpc "btIsA2dpPlaying" to BluetoothA2dpSnippet

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothA2dpSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/profiles/BluetoothA2dpSnippet.java
@@ -96,6 +96,12 @@ public class BluetoothA2dpSnippet implements Snippet {
         return mJsonSerializer.serializeBluetoothDeviceList(sA2dpProfile.getConnectedDevices());
     }
 
+    @Rpc(description = "Checks if a device is streaming audio via A2DP profile.")
+    public boolean btIsA2dpPlaying(String deviceAddress) throws Throwable {
+        BluetoothDevice device = getConnectedBluetoothDevice(deviceAddress);
+        return sA2dpProfile.isA2dpPlaying(device);
+    }
+
     private BluetoothDevice getConnectedBluetoothDevice(String deviceAddress)
             throws BluetoothA2dpSnippetException {
         for (BluetoothDevice device : sA2dpProfile.getConnectedDevices()) {


### PR DESCRIPTION
A RPC method is used to check A2DP audio path is enabled or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/128)
<!-- Reviewable:end -->
