### PR TITLE
update btBecomeDiscoverable to handle api level

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -203,8 +203,8 @@ public class BluetoothAdapterSnippet implements Snippet {
             throw new BluetoothAdapterSnippetException(
                     "Bluetooth is not enabled, cannot become discoverable.");
         }
-        // TODO change it to SDK version R after R is released.
-        if (Build.VERSION_CODES == Build.VERSION_CODES.CUR_DEVELOPMENT) {
+        // TODO change it to SDK version for R after R is released.
+        if (Build.VERSION.CODENAME.equals("R") || Build.VERSION.SDK_INT > 29) {
           if (!(boolean)
                 Utils.invokeByReflection(
                         mBluetoothAdapter,

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -203,7 +203,7 @@ public class BluetoothAdapterSnippet implements Snippet {
             throw new BluetoothAdapterSnippetException(
                     "Bluetooth is not enabled, cannot become discoverable.");
         }
-        // TODO jwang1013 change it to SDK version for R after R is released.
+        // TODO(jwang1013): change it to SDK version for R after R is released.
         if (Build.VERSION.CODENAME.equals("R") || Build.VERSION.SDK_INT > 29) {
           if (!(boolean)
                 Utils.invokeByReflection(

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -204,7 +204,7 @@ public class BluetoothAdapterSnippet implements Snippet {
                     "Bluetooth is not enabled, cannot become discoverable.");
         }
         // TODO change it to SDK version R after R is released.
-        if (Build.VERSION_CODES == 	Build.VERSION_CODES.CUR_DEVELOPMENT) {
+        if (Build.VERSION_CODES == Build.VERSION_CODES.CUR_DEVELOPMENT) {
           if (!(boolean)
                 Utils.invokeByReflection(
                         mBluetoothAdapter,

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -203,7 +203,8 @@ public class BluetoothAdapterSnippet implements Snippet {
             throw new BluetoothAdapterSnippetException(
                     "Bluetooth is not enabled, cannot become discoverable.");
         }
-        if (Build.VERSION.SDK_INT > 29) {
+        // TODO change it to SDK version R after R is released.
+        if (Build.VERSION_CODES == 	Build.VERSION_CODES.CUR_DEVELOPMENT) {
           if (!(boolean)
                 Utils.invokeByReflection(
                         mBluetoothAdapter,

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -22,6 +22,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.mobly.snippet.Snippet;
@@ -202,14 +203,25 @@ public class BluetoothAdapterSnippet implements Snippet {
             throw new BluetoothAdapterSnippetException(
                     "Bluetooth is not enabled, cannot become discoverable.");
         }
-        if (!(boolean)
+        if (Build.VERSION.SDK_INT > 29) {
+          if (!(boolean)
+                Utils.invokeByReflection(
+                        mBluetoothAdapter,
+                        "setScanMode",
+                        BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE,
+                        (long) duration * 1000)) {
+            throw new BluetoothAdapterSnippetException("Failed to become discoverable.");
+        } else {
+          if (!(boolean)
                 Utils.invokeByReflection(
                         mBluetoothAdapter,
                         "setScanMode",
                         BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE,
                         duration)) {
             throw new BluetoothAdapterSnippetException("Failed to become discoverable.");
+          }
         }
+      }
     }
 
     @Rpc(description = "Cancel ongoing bluetooth discovery.")

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -203,7 +203,7 @@ public class BluetoothAdapterSnippet implements Snippet {
             throw new BluetoothAdapterSnippetException(
                     "Bluetooth is not enabled, cannot become discoverable.");
         }
-        // TODO change it to SDK version for R after R is released.
+        // TODO jwang1013 change it to SDK version for R after R is released.
         if (Build.VERSION.CODENAME.equals("R") || Build.VERSION.SDK_INT > 29) {
           if (!(boolean)
                 Utils.invokeByReflection(


### PR DESCRIPTION
android api 29+ has changed the BluetoothAdapter.setScanMode signature from (Integer, Integer) to (Integer, Long). change btBecomeDiscoverable to handle different api level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/129)
<!-- Reviewable:end -->
