### PR TITLE
Have wifiClearConfiguredNetworks re-check network list to determine operation success.

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -78,18 +78,18 @@ public class WifiManagerSnippet implements Snippet {
                             + "networks were added through this MBS instance")
     public void wifiClearConfiguredNetworks() throws WifiManagerSnippetException {
         List<WifiConfiguration> unremovedConfigs = mWifiManager.getConfiguredNetworks();
-        List<WifiConfiguration> failedConfigs = new ArrayList<>();
         if (unremovedConfigs == null) {
             throw new WifiManagerSnippetException(
                     "Failed to get a list of configured networks. Is wifi disabled?");
         }
         for (WifiConfiguration config : unremovedConfigs) {
             if (!mWifiManager.removeNetwork(config.networkId)) {
-                failedConfigs.add(config);
+                Log.e("Encountered error while removing network: " + config);
             }
         }
-        if (!failedConfigs.isEmpty()) {
-            throw new WifiManagerSnippetException("Failed to remove networks: " + failedConfigs);
+        unremovedConfigs = mWifiManager.getConfiguredNetworks();
+        if (!unremovedConfigs.isEmpty()) {
+            throw new WifiManagerSnippetException("Failed to remove networks: " + unremovedConfigs);
         }
     }
 


### PR DESCRIPTION
Sometimes, a removeNetwork call could remove more than one configured network at a time (e.g. a network and its OWE config), so that the subsequent call may find its target config missing and return false. Currently, this will cause an exception to be raised, even though the intended outcome is achieved. Therefore, it is more reliable to simply verify that the configured network list is cleared by the end of the removal process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/146)
<!-- Reviewable:end -->
