### PR TITLE
Use intent to enable BT discoverability for T+; handle dialog with UIAutomator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
-        minSdkVersion 15
+        minSdkVersion 18
         // Set target to 22 to avoid having to deal with runtime permissions.
         targetSdkVersion 22
         versionCode 1
@@ -72,6 +72,7 @@ artifacts {
 
 dependencies {
     implementation 'androidx.test:runner:1.3.0'
+    implementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
     implementation 'com.google.android.mobly:mobly-snippet-lib:1.2.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:31.0.1-jre'

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -25,6 +25,10 @@ import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.Until;
 import com.google.android.mobly.snippet.Snippet;
 import com.google.android.mobly.snippet.bundled.utils.JsonSerializer;
 import com.google.android.mobly.snippet.bundled.utils.Utils;
@@ -34,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import org.json.JSONException;
 
 /** Snippet class exposing Android APIs in BluetoothAdapter. */
@@ -45,6 +50,10 @@ public class BluetoothAdapterSnippet implements Snippet {
 
         public BluetoothAdapterSnippetException(String msg) {
             super(msg);
+        }
+
+        public BluetoothAdapterSnippetException(String msg, Throwable err) {
+            super(msg, err);
         }
     }
 
@@ -91,6 +100,16 @@ public class BluetoothAdapterSnippet implements Snippet {
             }
         }
         return null;
+    }
+
+    /* Gets the UiDevice instance for UI operations. */
+    private static UiDevice getUiDevice() throws BluetoothAdapterSnippetException {
+        try {
+            return UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        } catch (IllegalStateException e) {
+            throw new BluetoothAdapterSnippetException("Failed to get UiDevice. Please ensure that "
+                    + "no other UiAutomation service is running.", e);
+        }
     }
 
     @Rpc(description = "Enable bluetooth with a 30s timeout.")
@@ -200,7 +219,19 @@ public class BluetoothAdapterSnippet implements Snippet {
             throw new BluetoothAdapterSnippetException(
                     "Bluetooth is not enabled, cannot become discoverable.");
         }
-        if (Build.VERSION.SDK_INT > 29) {
+        if (Build.VERSION.SDK_INT > 30) {
+            // setScanMode is removed from public SDK for T and above, so uses an intent instead.
+            UiDevice uiDevice = getUiDevice();
+            Intent discoverableIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);
+            discoverableIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            discoverableIntent.putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, duration);
+            // Triggers the system UI popup to ask for explicit permission.
+            mContext.startActivity(discoverableIntent);
+            // Clicks the "ALLOW" button.
+            BySelector allowButtonSelector = By.text(TEXT_PATTERN_ALLOW).clickable(true);
+            uiDevice.wait(Until.findObject(allowButtonSelector), 10);
+            uiDevice.findObject(allowButtonSelector).click();
+        } else if (Build.VERSION.SDK_INT > 29) {
             if (!(boolean)
                     Utils.invokeByReflection(
                             mBluetoothAdapter,
@@ -220,6 +251,9 @@ public class BluetoothAdapterSnippet implements Snippet {
             }
         }
     }
+
+    private static final Pattern TEXT_PATTERN_ALLOW =
+            Pattern.compile("allow", Pattern.CASE_INSENSITIVE);
 
     @Rpc(description = "Cancel ongoing bluetooth discovery.")
     public void btCancelDiscovery() throws BluetoothAdapterSnippetException {


### PR DESCRIPTION
The "BluetoothAdapter#setScanMode" API is no longer accessible to SDK versions 31 and above. Add a intent-based workflow according to https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#ACTION_REQUEST_DISCOVERABLE. Use UI Automator to interact with the pop-up user dialog.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/149)
<!-- Reviewable:end -->
