### PR TITLE
Add ScanRecord#getManufacturerSpecificData() to BLE Scan result.

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonSerializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonSerializer.java
@@ -27,6 +27,7 @@ import android.net.wifi.WifiInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.ParcelUuid;
+import android.util.SparseArray;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.lang.reflect.Modifier;
@@ -187,6 +188,20 @@ public class JsonSerializer {
         Bundle result = new Bundle();
         result.putString("DeviceName", record.getDeviceName());
         result.putInt("TxPowerLevel", record.getTxPowerLevel());
+        result.putBundle(
+            "manufacturerSpecificData", serializeBleScanManufacturerSpecificData(record));
+        return result;
+    }
+
+    /** Serialize manufacturer specific data from ScanRecord for Bluetooth LE. */
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private Bundle serializeBleScanManufacturerSpecificData(ScanRecord record) {
+        Bundle result = new Bundle();
+        SparseArray<byte[]> sparseArray = record.getManufacturerSpecificData();
+        for (int i = 0; i < sparseArray.size(); i++) {
+            int key = sparseArray.keyAt(i);
+            result.putByteArray(String.valueOf(key), sparseArray.get(key));
+        }
         return result;
     }
 


### PR DESCRIPTION
Returns a sparse array of manufacturer identifier and its corresponding manufacturer specific data.

API: https://developer.android.com/reference/android/bluetooth/le/ScanRecord#getManufacturerSpecificData()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/154)
<!-- Reviewable:end -->
