### PR TITLE
Modernize MBS including SDK version, dependencies and permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
 
         // NOTE: Do not place your application dependencies here.
     }
@@ -17,7 +17,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
@@ -29,14 +29,12 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
-        minSdkVersion 18
-        // Set target to 22 to avoid having to deal with runtime permissions.
-        targetSdkVersion 22
+        minSdkVersion 26
+        targetSdkVersion 31
         versionCode 1
         versionName "0.0.1"
         setProperty("archivesBaseName", "mobly-bundled-snippets")
@@ -71,14 +69,15 @@ artifacts {
 }
 
 dependencies {
-    implementation 'androidx.test:runner:1.3.0'
+    implementation 'androidx.test:runner:1.5.2'
+    implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
-    implementation 'com.google.android.mobly:mobly-snippet-lib:1.2.0'
+    implementation 'com.google.android.mobly:mobly-snippet-lib:1.4.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:31.0.1-jre'
-    implementation 'com.google.errorprone:error_prone_annotations:2.5.1'
+    implementation 'com.google.errorprone:error_prone_annotations:2.15.0'
 
-    testImplementation 'com.google.errorprone:error_prone_annotations:2.5.1'
+    testImplementation 'com.google.errorprone:error_prone_annotations:2.15.0'
     testImplementation 'com.google.guava:guava:31.0.1-jre'
     testImplementation 'com.google.truth:truth:1.1.2'
     testImplementation 'junit:junit:4.13.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />


### PR DESCRIPTION
1. Update JCenter to Maven Central as JCenter is shutting down in September 2022
2. Update Gradle from 4 (2017) to 7 (2022)
3. Update minSdkVersion from 18 to 26
4. Update targetSdkVersion from 22 to 31
5. Update AndroidX Test Library from 1.3.0 (2020) to 1.5.2 (2023)
6. Update Mobly Snippet Lib from 1.2.0 (2017) to 1.4.0 (2023)
7. Update Error Prone Annotations from 2.5.1 (2021) to 2.15.0 (2022)
8. Add MultiDex to fix `androidx.multidex.MultiDexApplication` missing issue
9. Add android.permission.BLUETOOTH_ADVERTISE permission for BLE advertising
10. Add android.permission.BLUETOOTH_SCAN permission for BLE scan

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/166)
<!-- Reviewable:end -->
