### PR TITLE
Support more features on BLE related API.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
 
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
@@ -12,6 +14,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
@@ -38,6 +41,8 @@
             android:value="com.google.android.mobly.snippet.bundled.AccountSnippet,
                            com.google.android.mobly.snippet.bundled.AudioSnippet,
                            com.google.android.mobly.snippet.bundled.bluetooth.BluetoothAdapterSnippet,
+                           com.google.android.mobly.snippet.bundled.bluetooth.BluetoothGattClientSnippet,
+                           com.google.android.mobly.snippet.bundled.bluetooth.BluetoothGattServerSnippet,
                            com.google.android.mobly.snippet.bundled.bluetooth.profiles.BluetoothA2dpSnippet,
                            com.google.android.mobly.snippet.bundled.bluetooth.profiles.BluetoothHearingAidSnippet,
                            com.google.android.mobly.snippet.bundled.BluetoothLeAdvertiserSnippet,

--- a/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothLeAdvertiserSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothLeAdvertiserSnippet.java
@@ -96,9 +96,9 @@ public class BluetoothLeAdvertiserSnippet implements Snippet {
      *          }
      *     </pre>
      *
-     * @param scanResponse A JSONObject representing a {@link AdvertiseData} object is returned when
-     *     a scanning device sends an active scan request. The data structure will be the same as
-     *     advertiseData.
+     * @param scanResponse A JSONObject representing a {@link AdvertiseData} object which saved the
+     *     advertisement data when a scanning device sends an active scan request. The data
+     *     structure will be the same as advertiseData.
      *
      * @throws BluetoothLeAdvertiserSnippetException
      * @throws JSONException

--- a/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothLeAdvertiserSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/BluetoothLeAdvertiserSnippet.java
@@ -96,9 +96,24 @@ public class BluetoothLeAdvertiserSnippet implements Snippet {
      *          }
      *     </pre>
      *
-     * @param scanResponse A JSONObject representing a {@link AdvertiseData} object which saved the
-     *     advertisement data when a scanning device sends an active scan request. The data
-     *     structure will be the same as advertiseData.
+     * @param scanResponse A JSONObject representing a {@link AdvertiseData} object which will
+     *     response the data to the scanning device. E.g.
+     *     <pre>
+     *          {
+     *            "IncludeDeviceName": (bool),
+     *            # JSON list, each element representing a set of service data, which is composed of
+     *            # a UUID, and an optional string.
+     *            "ServiceData": [
+     *                      {
+     *                        "UUID": (A string representation of {@link ParcelUuid}),
+     *                        "Data": (Optional, The string representation of what you want to
+     *                                 advertise, base64 encoded)
+     *                        # If you want to add a UUID without data, simply omit the "Data"
+     *                        # field.
+     *                      }
+     *                ]
+     *          }
+     *     </pre>
      *
      * @throws BluetoothLeAdvertiserSnippetException
      * @throws JSONException

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattClientSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattClientSnippet.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.bundled.bluetooth;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothProfile;
+import android.content.Context;
+import android.os.Build.VERSION_CODES;
+import android.os.Bundle;
+import android.os.SystemClock;
+import android.util.Base64;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.bundled.utils.JsonSerializer;
+import com.google.android.mobly.snippet.bundled.utils.MbsEnums;
+import com.google.android.mobly.snippet.event.EventCache;
+import com.google.android.mobly.snippet.event.SnippetEvent;
+import com.google.android.mobly.snippet.rpc.AsyncRpc;
+import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.rpc.RpcMinSdk;
+import com.google.android.mobly.snippet.util.Log;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.json.JSONException;
+
+/** Snippet class exposing Android APIs in BluetoothGatt. */
+public class BluetoothGattClientSnippet implements Snippet {
+    private static class BluetoothGattClientSnippetException extends Exception {
+        private static final long serialVersionUID = 1;
+
+        public BluetoothGattClientSnippetException(String msg) {
+            super(msg);
+        }
+    }
+
+    private final Context context;
+    private final EventCache eventCache;
+    private final HashMap<String, HashMap<String, BluetoothGattCharacteristic>>
+            characteristicHashMap;
+
+    private BluetoothGatt bluetoothGattClient;
+
+    private long connectionStartTime = 0;
+    private long connectionEndTime = 0;
+
+    public BluetoothGattClientSnippet() {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        eventCache = EventCache.getInstance();
+        characteristicHashMap = new HashMap<>();
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @AsyncRpc(description = "Start BLE client.")
+    public void bleConnectGatt(String callbackId, String deviceAddress) throws JSONException {
+        BluetoothDevice remoteDevice =
+                BluetoothAdapter.getDefaultAdapter().getRemoteDevice(deviceAddress);
+        BluetoothGattCallback gattCallback = new DefaultBluetoothGattCallback(callbackId);
+        connectionStartTime = System.currentTimeMillis();
+        bluetoothGattClient = remoteDevice.connectGatt(context, false, gattCallback);
+        Log.d("Connection start time is " + connectionStartTime);
+        connectionEndTime = 0;
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @Rpc(description = "Start BLE service discovery")
+    public long bleDiscoverServices() throws BluetoothGattClientSnippetException {
+        if (bluetoothGattClient == null) {
+            throw new BluetoothGattClientSnippetException("BLE client is not initialized.");
+        }
+        long discoverServicesStartTime = SystemClock.elapsedRealtimeNanos();
+        Log.d("Discover services start time is " + discoverServicesStartTime);
+        boolean result = bluetoothGattClient.discoverServices();
+        if (!result) {
+            throw new BluetoothGattClientSnippetException("Discover services returned false.");
+        }
+        return discoverServicesStartTime;
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @Rpc(description = "Stop BLE client.")
+    public void bleDisconnect() throws BluetoothGattClientSnippetException {
+        if (bluetoothGattClient == null) {
+            throw new BluetoothGattClientSnippetException("BLE client is not initialized.");
+        }
+        bluetoothGattClient.disconnect();
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @Rpc(description = "BLE read operation.")
+    public boolean bleReadOperation(String serviceUuid, String characteristicUuid)
+            throws JSONException, BluetoothGattClientSnippetException {
+        if (bluetoothGattClient == null) {
+            throw new BluetoothGattClientSnippetException("BLE client is not initialized.");
+        }
+        boolean result =
+                bluetoothGattClient.readCharacteristic(
+                        characteristicHashMap.get(serviceUuid).get(characteristicUuid));
+        Log.d("Read operation returned result " + result);
+        return result;
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @Rpc(description = "BLE write operation.")
+    public boolean bleWriteOperation(String serviceUuid, String characteristicUuid, String data)
+            throws JSONException, BluetoothGattClientSnippetException {
+        if (bluetoothGattClient == null) {
+            throw new BluetoothGattClientSnippetException("BLE client is not initialized.");
+        }
+        BluetoothGattCharacteristic characteristic =
+                characteristicHashMap.get(serviceUuid).get(characteristicUuid);
+        characteristic.setValue(Base64.decode(data, Base64.NO_WRAP));
+        boolean result = bluetoothGattClient.writeCharacteristic(characteristic);
+        Log.d("Write operation returned result " + result);
+        return result;
+    }
+
+    private class DefaultBluetoothGattCallback extends BluetoothGattCallback {
+        private final String callbackId;
+
+        DefaultBluetoothGattCallback(String callbackId) {
+            this.callbackId = callbackId;
+        }
+
+        @Override
+        public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
+            SnippetEvent event = new SnippetEvent(callbackId, "onConnectionStateChange");
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                connectionEndTime = System.currentTimeMillis();
+                event.getData().putLong(
+                        "gattConnectionTimeMs", connectionEndTime - connectionStartTime);
+                Log.d("Connection end time is " + connectionEndTime);
+            }
+            event.getData().putString("status", MbsEnums.BLE_STATUS_TYPE.getString(status));
+            event.getData().putString("newState", MbsEnums.BLE_CONNECT_STATUS.getString(newState));
+            event.getData().putBundle("gatt", JsonSerializer.serializeBluetoothGatt(gatt));
+            eventCache.postEvent(event);
+        }
+
+        @Override
+        public void onServicesDiscovered(BluetoothGatt gatt, int status) {
+            long discoverServicesEndTime = SystemClock.elapsedRealtimeNanos();
+            Log.d("Discover services end time is " + discoverServicesEndTime);
+            SnippetEvent event = new SnippetEvent(callbackId, "onServiceDiscovered");
+            event.getData().putString("status", MbsEnums.BLE_STATUS_TYPE.getString(status));
+            ArrayList<Bundle> services = new ArrayList<>();
+            for (BluetoothGattService service : gatt.getServices()) {
+                HashMap<String, BluetoothGattCharacteristic> characteristics = new HashMap<>();
+                for (BluetoothGattCharacteristic characteristic : service.getCharacteristics()) {
+                    characteristics.put(characteristic.getUuid().toString(), characteristic);
+                }
+                characteristicHashMap.put(service.getUuid().toString(), characteristics);
+                services.add(JsonSerializer.serializeBluetoothGattService(service));
+            }
+            // TODO(66740428): Should not return services directly
+            event.getData().putParcelableArrayList("Services", services);
+            event.getData().putBundle("gatt", JsonSerializer.serializeBluetoothGatt(gatt));
+            event.getData().putLong("discoveryServicesEndTime", discoverServicesEndTime);
+            eventCache.postEvent(event);
+        }
+
+        @Override
+        public void onCharacteristicRead(
+                BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+            SnippetEvent event = new SnippetEvent(callbackId, "onCharacteristicRead");
+            event.getData().putString("status", MbsEnums.BLE_STATUS_TYPE.getString(status));
+            // TODO(66740428): Should return the characteristic instead of value
+            event.getData()
+                    .putString("Data",
+                            Base64.encodeToString(characteristic.getValue(), Base64.NO_WRAP));
+            event.getData().putBundle("gatt", JsonSerializer.serializeBluetoothGatt(gatt));
+            eventCache.postEvent(event);
+        }
+
+        @Override
+        public void onCharacteristicWrite(
+                BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+            SnippetEvent event = new SnippetEvent(callbackId, "onCharacteristicWrite");
+            event.getData().putString("status", MbsEnums.BLE_STATUS_TYPE.getString(status));
+            // TODO(66740428): Should return the characteristic instead of value
+            event.getData().putBundle("gatt", JsonSerializer.serializeBluetoothGatt(gatt));
+            eventCache.postEvent(event);
+        }
+
+        @Override
+        public void onReliableWriteCompleted(BluetoothGatt gatt, int status) {
+            SnippetEvent event = new SnippetEvent(callbackId, "onReliableWriteCompleted");
+            event.getData().putString("status", MbsEnums.BLE_STATUS_TYPE.getString(status));
+            event.getData().putBundle("gatt", JsonSerializer.serializeBluetoothGatt(gatt));
+            eventCache.postEvent(event);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (bluetoothGattClient != null) {
+            bluetoothGattClient.close();
+        }
+    }
+}

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattClientSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattClientSnippet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc.
+ * Copyright (C) 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattServerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattServerSnippet.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.bundled.bluetooth;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattServer;
+import android.bluetooth.BluetoothGattServerCallback;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothManager;
+import android.content.Context;
+import android.os.Build.VERSION_CODES;
+import android.os.DeadObjectException;
+import android.os.SystemClock;
+import android.util.Base64;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.bundled.utils.DataHolder;
+import com.google.android.mobly.snippet.bundled.utils.JsonDeserializer;
+import com.google.android.mobly.snippet.bundled.utils.JsonSerializer;
+import com.google.android.mobly.snippet.bundled.utils.MbsEnums;
+import com.google.android.mobly.snippet.event.EventCache;
+import com.google.android.mobly.snippet.event.SnippetEvent;
+import com.google.android.mobly.snippet.rpc.AsyncRpc;
+import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.rpc.RpcMinSdk;
+import com.google.android.mobly.snippet.util.Log;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** Snippet class exposing Android APIs in BluetoothGattServer. */
+public class BluetoothGattServerSnippet implements Snippet {
+    private static class BluetoothGattServerSnippetException extends Exception {
+        private static final long serialVersionUID = 1;
+
+        public BluetoothGattServerSnippetException(String msg) {
+            super(msg);
+        }
+    }
+
+    private final Context context;
+    private final BluetoothManager bluetoothManager;
+    private final DataHolder dataHolder;
+    private final EventCache eventCache;
+
+    private BluetoothGattServer bluetoothGattServer;
+
+    public BluetoothGattServerSnippet() {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        bluetoothManager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+        dataHolder = new DataHolder();
+        eventCache = EventCache.getInstance();
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @AsyncRpc(description = "Start BLE server.")
+    public void bleStartServer(String callbackId, JSONArray services)
+            throws JSONException, DeadObjectException {
+        BluetoothGattServerCallback gattServerCallback =
+                new DefaultBluetoothGattServerCallback(callbackId);
+        bluetoothGattServer = bluetoothManager.openGattServer(context, gattServerCallback);
+        addServiceToGattServer(services);
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @AsyncRpc(description = "Start BLE server with workaround.")
+    public void bleStartServerWithWorkaround(String callbackId, JSONArray services)
+            throws JSONException, DeadObjectException {
+        BluetoothGattServerCallback gattServerCallback =
+                new DefaultBluetoothGattServerCallback(callbackId);
+        boolean isGattServerStarted = false;
+        int count = 0;
+        while (!isGattServerStarted && count < 5) {
+            bluetoothGattServer = bluetoothManager.openGattServer(context, gattServerCallback);
+            if (bluetoothGattServer != null) {
+                addServiceToGattServer(services);
+                isGattServerStarted = true;
+            } else {
+                SystemClock.sleep(1000);
+                count++;
+            }
+        }
+    }
+
+    private void addServiceToGattServer(JSONArray services) throws JSONException {
+        for (int i = 0; i < services.length(); i++) {
+            JSONObject service = services.getJSONObject(i);
+            BluetoothGattService bluetoothGattService =
+                    JsonDeserializer.jsonToBluetoothGattService(dataHolder, service);
+            bluetoothGattServer.addService(bluetoothGattService);
+        }
+    }
+
+    @RpcMinSdk(VERSION_CODES.LOLLIPOP)
+    @Rpc(description = "Stop BLE server.")
+    public void bleStopServer() throws BluetoothGattServerSnippetException {
+        if (bluetoothGattServer == null) {
+            throw new BluetoothGattServerSnippetException("BLE server is not initialized.");
+        }
+        bluetoothGattServer.close();
+    }
+
+    private class DefaultBluetoothGattServerCallback extends BluetoothGattServerCallback {
+        private final String callbackId;
+
+        DefaultBluetoothGattServerCallback(String callbackId) {
+            this.callbackId = callbackId;
+        }
+
+        @Override
+        public void onConnectionStateChange(BluetoothDevice device, int status, int newState) {
+            SnippetEvent event = new SnippetEvent(callbackId, "onConnectionStateChange");
+            event.getData().putBundle("device", JsonSerializer.serializeBluetoothDevice(device));
+            event.getData().putString("status", MbsEnums.BLE_STATUS_TYPE.getString(status));
+            event.getData().putString("newState", MbsEnums.BLE_CONNECT_STATUS.getString(newState));
+            eventCache.postEvent(event);
+        }
+
+        @Override
+        public void onServiceAdded(int status, BluetoothGattService service) {
+            Log.d("Bluetooth Gatt Server service added with status " + status);
+            SnippetEvent event = new SnippetEvent(callbackId, "onServiceAdded");
+            event.getData().putString("status", MbsEnums.BLE_STATUS_TYPE.getString(status));
+            event.getData()
+                    .putParcelable("Service",
+                                  JsonSerializer.serializeBluetoothGattService(service));
+            eventCache.postEvent(event);
+        }
+
+        @Override
+        public void onCharacteristicReadRequest(
+                BluetoothDevice device,
+                int requestId,
+                int offset,
+                BluetoothGattCharacteristic characteristic) {
+            Log.d("Bluetooth Gatt Server received a read request");
+            if (dataHolder.get(characteristic) != null) {
+                bluetoothGattServer.sendResponse(
+                        device,
+                        requestId,
+                        BluetoothGatt.GATT_SUCCESS,
+                        offset,
+                        Base64.decode(dataHolder.get(characteristic), Base64.NO_WRAP));
+            } else {
+                bluetoothGattServer.sendResponse(
+                        device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null);
+            }
+        }
+
+        @Override
+        public void onCharacteristicWriteRequest(
+                BluetoothDevice device,
+                int requestId,
+                BluetoothGattCharacteristic characteristic,
+                boolean preparedWrite,
+                boolean responseNeeded,
+                int offset,
+                byte[] value) {
+            Log.d("Bluetooth Gatt Server received a write request");
+            bluetoothGattServer.sendResponse(
+                    device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null);
+            SnippetEvent event = new SnippetEvent(callbackId, "onCharacteristicWriteRequest");
+            event.getData().putString("Data", Base64.encodeToString(value, Base64.NO_WRAP));
+            eventCache.postEvent(event);
+        }
+
+        @Override
+        public void onExecuteWrite(BluetoothDevice device, int requestId, boolean execute) {
+            Log.d("Bluetooth Gatt Server received an execute write request");
+            bluetoothGattServer.sendResponse(
+                    device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null);
+        }
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattServerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothGattServerSnippet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc.
+ * Copyright (C) 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/DataHolder.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/DataHolder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.bundled.utils;
+
+import android.bluetooth.BluetoothGattCharacteristic;
+import java.util.HashMap;
+
+/** A holder to hold android objects for snippets. */
+public class DataHolder {
+    private final HashMap<BluetoothGattCharacteristic, String> dataToBeRead;
+
+    public DataHolder() {
+        dataToBeRead = new HashMap<>();
+    }
+
+    public String get(BluetoothGattCharacteristic characteristic) {
+        return dataToBeRead.get(characteristic);
+    }
+
+    public void insertData(BluetoothGattCharacteristic characteristic, String string) {
+        dataToBeRead.put(characteristic, string);
+    }
+}

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/DataHolder.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/DataHolder.java
@@ -20,6 +20,7 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import java.util.HashMap;
 
 /** A holder to hold android objects for snippets. */
+// TODO(ko1in1u): For future extensions between Snippet classes and Utils.
 public class DataHolder {
     private final HashMap<BluetoothGattCharacteristic, String> dataToBeRead;
 

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/DataHolder.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/DataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc.
+ * Copyright (C) 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
@@ -1,9 +1,31 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.android.mobly.snippet.bundled.utils;
 
 import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothProfile;
+import android.bluetooth.le.AdvertiseCallback;
 import android.bluetooth.le.AdvertiseSettings;
 import android.bluetooth.le.ScanCallback;
 import android.bluetooth.le.ScanSettings;
+import android.net.wifi.WifiManager.LocalOnlyHotspotCallback;
 import android.os.Build;
 
 /** Mobly Bundled Snippets (MBS)'s {@link RpcEnum} objects representing enums in Android APIs. */
@@ -15,6 +37,27 @@ public class MbsEnums {
             buildBleScanResultCallbackTypeEnum();
     static final RpcEnum BLUETOOTH_DEVICE_BOND_STATE = buildBluetoothDeviceBondState();
     static final RpcEnum BLUETOOTH_DEVICE_TYPE = buildBluetoothDeviceTypeEnum();
+    static final RpcEnum BLE_SERVICE_TYPE = buildServiceTypeEnum();
+    public static final RpcEnum BLE_STATUS_TYPE = buildStatusTypeEnum();
+    public static final RpcEnum BLE_CONNECT_STATUS = buildConnectStatusEnum();
+    static final RpcEnum BLE_PROPERTY_TYPE = buildPropertyTypeEnum();
+    static final RpcEnum BLE_PERMISSION_TYPE = buildPermissionTypeEnum();
+    static final RpcEnum BLE_SCAN_MODE = buildBleScanModeEnum();
+    public static final RpcEnum LOCAL_HOTSPOT_FAIL_REASON = buildLocalHotspotFailedReason();
+    public static final RpcEnum ADVERTISE_FAILURE_ERROR_CODE =
+            new RpcEnum.Builder().add("ADVERTISE_FAILED_ALREADY_STARTED",
+                                     AdvertiseCallback.ADVERTISE_FAILED_ALREADY_STARTED)
+                    .add("ADVERTISE_FAILED_DATA_TOO_LARGE",
+                        AdvertiseCallback.ADVERTISE_FAILED_DATA_TOO_LARGE)
+                    .add(
+                        "ADVERTISE_FAILED_FEATURE_UNSUPPORTED",
+                        AdvertiseCallback.ADVERTISE_FAILED_FEATURE_UNSUPPORTED)
+                    .add("ADVERTISE_FAILED_INTERNAL_ERROR",
+                        AdvertiseCallback.ADVERTISE_FAILED_INTERNAL_ERROR)
+                    .add(
+                        "ADVERTISE_FAILED_TOO_MANY_ADVERTISERS",
+                        AdvertiseCallback.ADVERTISE_FAILED_TOO_MANY_ADVERTISERS)
+                    .build();
 
     private static RpcEnum buildBluetoothDeviceBondState() {
         RpcEnum.Builder builder = new RpcEnum.Builder();
@@ -87,6 +130,127 @@ public class MbsEnums {
             builder.add("CALLBACK_TYPE_FIRST_MATCH", ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
             builder.add("CALLBACK_TYPE_MATCH_LOST", ScanSettings.CALLBACK_TYPE_MATCH_LOST);
         }
+        return builder.build();
+    }
+
+    private static RpcEnum buildServiceTypeEnum() {
+        RpcEnum.Builder builder = new RpcEnum.Builder();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return builder.build();
+        }
+        builder.add("SERVICE_TYPE_PRIMARY", BluetoothGattService.SERVICE_TYPE_PRIMARY);
+        builder.add("SERVICE_TYPE_SECONDARY", BluetoothGattService.SERVICE_TYPE_SECONDARY);
+        return builder.build();
+    }
+
+    private static RpcEnum buildStatusTypeEnum() {
+        RpcEnum.Builder builder = new RpcEnum.Builder();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return builder.build();
+        }
+        builder.add("GATT_SUCCESS", BluetoothGatt.GATT_SUCCESS)
+                .add("GATT_CONNECTION_CONGESTED", BluetoothGatt.GATT_CONNECTION_CONGESTED)
+                .add("GATT_FAILURE", BluetoothGatt.GATT_FAILURE)
+                .add("GATT_INSUFFICIENT_AUTHENTICATION",
+                    BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION)
+                .add("GATT_INSUFFICIENT_ENCRYPTION", BluetoothGatt.GATT_INSUFFICIENT_ENCRYPTION)
+                .add("GATT_INVALID_ATTRIBUTE_LENGTH", BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH)
+                .add("GATT_INVALID_OFFSET", BluetoothGatt.GATT_INVALID_OFFSET)
+                .add("GATT_READ_NOT_PERMITTED", BluetoothGatt.GATT_READ_NOT_PERMITTED)
+                .add("GATT_REQUEST_NOT_SUPPORTED", BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED)
+                .add("GATT_WRITE_NOT_PERMITTED", BluetoothGatt.GATT_WRITE_NOT_PERMITTED)
+                .add("BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION", 0x13)
+                .add("BLE_HCI_LOCAL_HOST_TERMINATED_CONNECTION", 0x12)
+                .add("BLE_HCI_STATUS_CODE_LMP_RESPONSE_TIMEOUT", 0x22)
+                .add("BLE_HCI_CONN_FAILED_TO_BE_ESTABLISHED", 0x3e)
+                .add("UNEXPECTED_DISCONNECT_NO_ERROR_CODE", 134)
+                .add("DID_NOT_FIND_OFFLINEP2P_SERVICE", 135)
+                .add("MISSING_CHARACTERISTIC", 137)
+                .add("CONNECTION_TIMEOUT", 138)
+                .add("READ_MALFORMED_VERSION", 139)
+                .add("READ_WRITE_VERSION_NONSPECIFIC_ERROR", 140)
+                .add("GATT_0C_err", 0X0C)
+                .add("GATT_16", 0x16)
+                .add("GATT_INTERNAL_ERROR", 129)
+                .add("BLE_HCI_CONNECTION_TIMEOUT", 0x08)
+                .add("GATT_ERROR", 133);
+        return builder.build();
+    }
+
+    private static RpcEnum buildConnectStatusEnum() {
+        RpcEnum.Builder builder = new RpcEnum.Builder();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return builder.build();
+        }
+        builder.add("STATE_CONNECTED", BluetoothProfile.STATE_CONNECTED)
+                .add("STATE_CONNECTING", BluetoothProfile.STATE_CONNECTING)
+                .add("STATE_DISCONNECTED", BluetoothProfile.STATE_DISCONNECTED)
+                .add("STATE_DISCONNECTING", BluetoothProfile.STATE_DISCONNECTING);
+        return builder.build();
+    }
+
+    private static RpcEnum buildPropertyTypeEnum() {
+        RpcEnum.Builder builder = new RpcEnum.Builder();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return builder.build();
+        }
+        builder
+                .add("PROPERTY_NONE", 0)
+                .add("PROPERTY_BROADCAST", BluetoothGattCharacteristic.PROPERTY_BROADCAST)
+                .add("PROPERTY_EXTENDED_PROPS", BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS)
+                .add("PROPERTY_INDICATE", BluetoothGattCharacteristic.PROPERTY_INDICATE)
+                .add("PROPERTY_NOTIFY", BluetoothGattCharacteristic.PROPERTY_NOTIFY)
+                .add("PROPERTY_READ", BluetoothGattCharacteristic.PROPERTY_READ)
+                .add("PROPERTY_SIGNED_WRITE", BluetoothGattCharacteristic.PROPERTY_SIGNED_WRITE)
+                .add("PROPERTY_WRITE", BluetoothGattCharacteristic.PROPERTY_WRITE)
+                .add("PROPERTY_WRITE_NO_RESPONSE",
+                    BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE);
+        return builder.build();
+    }
+
+    private static RpcEnum buildPermissionTypeEnum() {
+        RpcEnum.Builder builder = new RpcEnum.Builder();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return builder.build();
+        }
+        builder.add("PERMISSION_NONE", 0)
+              .add("PERMISSION_READ", BluetoothGattCharacteristic.PERMISSION_READ)
+              .add("PERMISSION_READ_ENCRYPTED",
+                  BluetoothGattCharacteristic.PERMISSION_READ_ENCRYPTED)
+              .add("PERMISSION_READ_ENCRYPTED_MITM",
+                  BluetoothGattCharacteristic.PERMISSION_READ_ENCRYPTED_MITM)
+              .add("PERMISSION_WRITE", BluetoothGattCharacteristic.PERMISSION_WRITE)
+              .add("PERMISSION_WRITE_ENCRYPTED",
+                  BluetoothGattCharacteristic.PERMISSION_WRITE_ENCRYPTED)
+              .add("PERMISSION_WRITE_ENCRYPTED_MITM",
+                  BluetoothGattCharacteristic.PERMISSION_WRITE_ENCRYPTED_MITM)
+              .add("PERMISSION_WRITE_SIGNED", BluetoothGattCharacteristic.PERMISSION_WRITE_SIGNED)
+              .add("PERMISSION_WRITE_SIGNED_MITM",
+                  BluetoothGattCharacteristic.PERMISSION_WRITE_SIGNED_MITM);
+        return builder.build();
+    }
+
+    private static RpcEnum buildBleScanModeEnum() {
+        RpcEnum.Builder builder = new RpcEnum.Builder();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return builder.build();
+        }
+        builder.add("SCAN_MODE_LOW_POWER", ScanSettings.SCAN_MODE_LOW_POWER)
+                .add("SCAN_MODE_BALANCED", ScanSettings.SCAN_MODE_BALANCED)
+                .add("SCAN_MODE_LOW_LATENCY", ScanSettings.SCAN_MODE_LOW_LATENCY);
+        return builder.build();
+    }
+
+    private static RpcEnum buildLocalHotspotFailedReason() {
+        RpcEnum.Builder builder = new RpcEnum.Builder();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return builder.build();
+        }
+        builder.add("ERROR_TETHERING_DISALLOWED",
+                   LocalOnlyHotspotCallback.ERROR_TETHERING_DISALLOWED)
+                .add("ERROR_INCOMPATIBLE_MODE", LocalOnlyHotspotCallback.ERROR_INCOMPATIBLE_MODE)
+                .add("ERROR_NO_CHANNEL", LocalOnlyHotspotCallback.ERROR_NO_CHANNEL)
+                .add("ERROR_GENERIC", LocalOnlyHotspotCallback.ERROR_GENERIC);
         return builder.build();
     }
 }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/RpcEnum.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/RpcEnum.java
@@ -17,6 +17,7 @@
 package com.google.android.mobly.snippet.bundled.utils;
 
 import com.google.common.collect.ImmutableBiMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * A container type for handling String-Integer enum conversion in Rpc protocol.
@@ -27,20 +28,20 @@ import com.google.common.collect.ImmutableBiMap;
  * <p>Once built, an RpcEnum object is immutable.
  */
 public class RpcEnum {
-    private final ImmutableBiMap<String, Integer> mEnums;
+    private final ImmutableBiMap<String, Integer> enums;
 
     private RpcEnum(ImmutableBiMap.Builder<String, Integer> builder) {
-        mEnums = builder.buildOrThrow();
+        enums = builder.buildOrThrow();
     }
 
     /**
      * Get the int value of an enum based on its String value.
      *
      * @param enumString
-     * @return
+     * @return int value
      */
     public int getInt(String enumString) {
-        Integer result = mEnums.get(enumString);
+        Integer result = enums.get(enumString);
         if (result == null) {
             throw new NoSuchFieldError("No int value found for: " + enumString);
         }
@@ -51,12 +52,12 @@ public class RpcEnum {
      * Get the String value of an enum based on its int value.
      *
      * @param enumInt
-     * @return
+     * @return string value
      */
     public String getString(int enumInt) {
-        String result = mEnums.inverse().get(enumInt);
+        String result = enums.inverse().get(enumInt);
         if (result == null) {
-            throw new NoSuchFieldError("No String value found for: " + enumInt);
+            return String.format("UNKNOWN_VALUE[%s].", enumInt);
         }
         return result;
     }
@@ -76,6 +77,7 @@ public class RpcEnum {
          * @param enumInt
          * @return
          */
+        @CanIgnoreReturnValue
         public Builder add(String enumString, int enumInt) {
             builder.put(enumString, enumInt);
             return this;


### PR DESCRIPTION
1. Support passing `scanResponse` to BLE advertising.
2. Support passing `scanFilters` and `scanSettings` to BLE scanning.
3. Support BluetoothGatt APIs.
4. Support BluetoothGattServer APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/167)
<!-- Reviewable:end -->
