### PR TITLE
Roll back PR-176

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/SmsSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/SmsSnippet.java
@@ -84,7 +84,13 @@ public class SmsSnippet implements Snippet {
         if (message.length() > MAX_CHAR_COUNT_PER_SMS) {
             ArrayList<String> parts = mSmsManager.divideMessage(message);
             receiver.setExpectedMessageCount(parts.size());
-            mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
+            if (Build.VERSION.SDK_INT >= 33) {
+                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION), null,
+                        null,
+                        Context.RECEIVER_EXPORTED);
+            } else {
+                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
+            }
             mSmsManager.sendMultipartTextMessage(
                     /* destinationAddress= */ phoneNumber,
                     /* scAddress= */ null,
@@ -107,7 +113,13 @@ public class SmsSnippet implements Snippet {
                             /* intent= */ new Intent(SMS_SENT_ACTION),
                             /* flags= */ PendingIntent.FLAG_IMMUTABLE);
             receiver.setExpectedMessageCount(1);
-            mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
+            if (Build.VERSION.SDK_INT >= 33) {
+                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION), null,
+                    null,
+                    Context.RECEIVER_EXPORTED);
+            } else {
+                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
+            }
             mSmsManager.sendTextMessage(
                     /* destinationAddress= */ phoneNumber,
                     /* scAddress= */ null,

--- a/src/main/java/com/google/android/mobly/snippet/bundled/SmsSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/SmsSnippet.java
@@ -84,13 +84,7 @@ public class SmsSnippet implements Snippet {
         if (message.length() > MAX_CHAR_COUNT_PER_SMS) {
             ArrayList<String> parts = mSmsManager.divideMessage(message);
             receiver.setExpectedMessageCount(parts.size());
-            if (Build.VERSION.SDK_INT >= 33) {
-                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION), null,
-                        null,
-                        Context.RECEIVER_EXPORTED);
-            } else {
-                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
-            }
+            mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
             mSmsManager.sendMultipartTextMessage(
                     /* destinationAddress= */ phoneNumber,
                     /* scAddress= */ null,
@@ -113,13 +107,7 @@ public class SmsSnippet implements Snippet {
                             /* intent= */ new Intent(SMS_SENT_ACTION),
                             /* flags= */ PendingIntent.FLAG_IMMUTABLE);
             receiver.setExpectedMessageCount(1);
-            if (Build.VERSION.SDK_INT >= 33) {
-                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION), null,
-                    null,
-                    Context.RECEIVER_EXPORTED);
-            } else {
-                mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
-            }
+            mContext.registerReceiver(receiver, new IntentFilter(SMS_SENT_ACTION));
             mSmsManager.sendTextMessage(
                     /* destinationAddress= */ phoneNumber,
                     /* scAddress= */ null,


### PR DESCRIPTION
Roll back changes for `Add RECEIVER_EXPORTED flag to portrait sys ui register receiver calls` [PR-176](https://github.com/google/mobly-bundled-snippets/pull/176)
Changes verified on APIs 31,33,34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/177)
<!-- Reviewable:end -->
