### PR TITLE
Fix Error Prone

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -35,8 +35,6 @@ import com.google.android.mobly.snippet.bundled.utils.Utils;
 import com.google.android.mobly.snippet.rpc.Rpc;
 import com.google.android.mobly.snippet.rpc.RpcMinSdk;
 import com.google.android.mobly.snippet.util.Log;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONArray;

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/BluetoothAdapterSnippet.java
@@ -343,7 +343,7 @@ public class BluetoothAdapterSnippet implements Snippet {
             throws BluetoothAdapterSnippetException, InterruptedException, JSONException {
         ArrayList<Bundle> pairedDevices = new ArrayList<>();
         for (BluetoothDevice device : mBluetoothAdapter.getBondedDevices()) {
-            pairedDevices.add(mJsonSerializer.serializeBluetoothDevice(device));
+            pairedDevices.add(JsonSerializer.serializeBluetoothDevice(device));
         }
         return pairedDevices;
     }

--- a/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/PairingBroadcastReceiver.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/bluetooth/PairingBroadcastReceiver.java
@@ -20,6 +20,7 @@ public class PairingBroadcastReceiver extends BroadcastReceiver {
         Utils.adaptShellPermissionIfRequired(mContext);
     }
 
+    @Override
     public void onReceive(Context context, Intent intent) {
         String action = intent.getAction();
         if (action.equals(BluetoothDevice.ACTION_PAIRING_REQUEST)) {


### PR DESCRIPTION
- StaticQualifiedUsingExpression: Static method serializeBluetoothDevice should not be accessed from an object instance; instead use JsonSerializer.serializeBluetoothDevice
- MissingOverride: onReceive implements method in BroadcastReceiver; expected @Override
- RemoveUnusedImports: Unused imports: java.lang.reflect.InvocationTargetException, java.lang.reflect.Method

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/178)
<!-- Reviewable:end -->
