### PR TITLE
Refactor manufacturerSpecificData to ManufacturerSpecificData

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
@@ -101,7 +101,8 @@ public class JsonDeserializer {
             JSONObject manufacturerData = jsonObject.getJSONObject("ManufacturerData");
             int manufacturerId = manufacturerData.getInt("ManufacturerId");
             byte[] manufacturerSpecificData =
-                    Base64.decode(jsonObject.getString("ManufacturerSpecificData"), Base64.DEFAULT);
+                    Base64.decode(
+                            manufacturerData.getString("ManufacturerSpecificData"), Base64.DEFAULT);
             builder.addManufacturerData(manufacturerId, manufacturerSpecificData);
         }
         return builder.build();


### PR DESCRIPTION
`manufacturerSpecificData` is one of arguments when adding manufacturer specific data (see [AdvertiseData.Builder#addManufacturerData](https://developer.android.com/reference/android/bluetooth/le/AdvertiseData.Builder#public-methods_1))

Before Change:

```
ad.mbs.bleStartAdvertising(
    advertiseSettings,
    {
        'IncludeDeviceName': True,
        'ManufacturerData': {'ManufacturerId': 224},
        'ManufacturerSpecificData': '[0x78, 0x01]',
    },
)
```

After Change:

```
ad.mbs.bleStartAdvertising(
    advertiseSettings,
    {
        'IncludeDeviceName': True,
        'ManufacturerData': {
                'ManufacturerId': 224,
                'ManufacturerSpecificData': '[0x78, 0x01]',
        },
    },
)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/179)
<!-- Reviewable:end -->
