### PR TITLE
Update version check for deprecated getCallState and getNetworkType

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -47,7 +47,7 @@ public class TelephonySnippet implements Snippet {
                     "Gets the call state for the default subscription. Call state values are"
                             + "0: IDLE, 1: RINGING, 2: OFFHOOK")
     public int getTelephonyCallState() {
-        return mTelephonyManager.getCallState();
+        return mTelephonyManager.getCallStateForSubscription();
     }
 
     @Rpc(

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -47,7 +47,11 @@ public class TelephonySnippet implements Snippet {
                     "Gets the call state for the default subscription. Call state values are"
                             + "0: IDLE, 1: RINGING, 2: OFFHOOK")
     public int getTelephonyCallState() {
-        return mTelephonyManager.getCallStateForSubscription();
+        if (Build.VERSION.SDK_INT < 31) {
+            return mTelephonyManager.getCallState();
+        } else {
+            return mTelephonyManager.getCallStateForSubscription();
+        }
     }
 
     @Rpc(
@@ -55,11 +59,7 @@ public class TelephonySnippet implements Snippet {
                     "Returns a constant indicating the radio technology (network type) currently"
                             + "in use on the device for data transmission.")
     public int getDataNetworkType() {
-        if (Build.VERSION.SDK_INT < 31) {
-            return mTelephonyManager.getDataNetworkType();
-        } else {
-            return mTelephonyManager.getCallStateForSubscription();
-        }
+        return mTelephonyManager.getDataNetworkType();
     }
 
     @Rpc(

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -59,7 +59,11 @@ public class TelephonySnippet implements Snippet {
                     "Returns a constant indicating the radio technology (network type) currently"
                             + "in use on the device for data transmission.")
     public int getDataNetworkType() {
-        return mTelephonyManager.getDataNetworkType();
+        if (Build.VERSION.SDK_INT < 30) {
+            return mTelephonyManager.getNetworkType();
+        } else {
+            return mTelephonyManager.getDataNetworkType();
+        }
     }
 
     @Rpc(

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -55,7 +55,11 @@ public class TelephonySnippet implements Snippet {
                     "Returns a constant indicating the radio technology (network type) currently"
                             + "in use on the device for data transmission.")
     public int getDataNetworkType() {
-      return mTelephonyManager.getDataNetworkType();
+        if (Build.VERSION.SDK_INT < 31) {
+            return mTelephonyManager.getDataNetworkType();
+        } else {
+            return mTelephonyManager.getCallStateForSubscription();
+        }
     }
 
     @Rpc(


### PR DESCRIPTION
getCallState was deprecated, use getCallStateForSubscription to get the call state.

https://developer.android.com/reference/android/telephony/TelephonyManager#getCallState%28%29

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/180)
<!-- Reviewable:end -->
