### PR TITLE
Fix error: package Build does not exist

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -17,6 +17,7 @@
 package com.google.android.mobly.snippet.bundled;
 
 import android.content.Context;
+import android.os.Build;
 import android.telephony.TelephonyManager;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.mobly.snippet.Snippet;


### PR DESCRIPTION
```
src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java:50: error: package Build does not exist
        if (Build.VERSION.SDK_INT < 31) {
                 ^
src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java:62: error: package Build does not exist
        if (Build.VERSION.SDK_INT < 30) {
                 ^
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/181)
<!-- Reviewable:end -->
