### PR TITLE
Update deprecated API and allow access to dual-sim device

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,12 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
-        minSdkVersion 26
-        targetSdkVersion 31
+        minSdk 26
+        targetSdk 34
         versionCode 1
         versionName "0.0.1"
         setProperty("archivesBaseName", "mobly-bundled-snippets")

--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,12 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 34
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
         minSdk 26
-        targetSdk 34
+        targetSdk 33
         versionCode 1
         versionName "0.0.1"
         setProperty("archivesBaseName", "mobly-bundled-snippets")

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -18,6 +18,8 @@ package com.google.android.mobly.snippet.bundled;
 
 import android.content.Context;
 import android.os.Build;
+import android.telephony.SubscriptionInfo;
+import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.mobly.snippet.Snippet;
@@ -27,15 +29,33 @@ import com.google.android.mobly.snippet.rpc.Rpc;
 public class TelephonySnippet implements Snippet {
 
     private final TelephonyManager mTelephonyManager;
+    private final SubscriptionManager mSubscriptionManager;
 
     public TelephonySnippet() {
         Context context = InstrumentationRegistry.getInstrumentation().getContext();
         mTelephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        mSubscriptionManager = (SubscriptionManager) context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE);
     }
 
     @Rpc(description = "Gets the line 1 phone number.")
     public String getLine1Number() {
         return mTelephonyManager.getLine1Number();
+    }
+
+    @Rpc(description = "Gets phone number for the simSlot (slot# start from 0, only valid for API level > 32)."
+                                + " API level <33 will always return phone number for simSlotIndex = 0")
+    public String getPhoneNumber(int simSlot) {
+        String thisNumber = "";
+
+        if (Build.VERSION.SDK_INT < 33) {
+            thisNumber = mTelephonyManager.getLine1Number();
+        } else {
+            SubscriptionInfo mSubscriptionInfo = mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot);
+            if (mSubscriptionInfo != null) {
+                thisNumber = mSubscriptionManager.getPhoneNumber(mSubscriptionInfo.getSubscriptionId());
+            }
+        }
+        return thisNumber;
     }
 
     @Rpc(description = "Returns the unique subscriber ID, for example, the IMSI for a GSM phone.")
@@ -53,6 +73,28 @@ public class TelephonySnippet implements Snippet {
         } else {
             return mTelephonyManager.getCallStateForSubscription();
         }
+    }
+
+    @Rpc(
+            description =
+                    "Gets the call state for the simSlot (slot# start from 0, only valid for API level > 30). Call state values are"
+                            + "0: IDLE, 1: RINGING, 2: OFFHOOK.")
+    public int getTelephonyCallState(int simSlot) {
+        int thisState = -1;
+
+        if (Build.VERSION.SDK_INT < 31) {
+            thisState = mTelephonyManager.getCallState();
+        } else {
+            SubscriptionInfo mSubscriptionInfo = mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot);
+            if (mSubscriptionInfo != null) {
+                thisState =
+                        mTelephonyManager
+                                .createForSubscriptionId(mSubscriptionInfo.getSubscriptionId())
+                                .getCallStateForSubscription();
+            }
+        }
+
+        return thisState;
     }
 
     @Rpc(

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -47,7 +47,7 @@ public class TelephonySnippet implements Snippet {
     public String getLine1Number(@RpcDefault("0") Integer simSlot) {
         String thisNumber = "";
 
-        if (Build.VERSION.SDK_INT < 33 || simSlot == null) {
+        if (Build.VERSION.SDK_INT < 33) {
             thisNumber = mTelephonyManager.getLine1Number();
         } else {
             SubscriptionInfo mSubscriptionInfo =
@@ -77,7 +77,7 @@ public class TelephonySnippet implements Snippet {
 
         if (Build.VERSION.SDK_INT < 31) {
             return mTelephonyManager.getCallState();
-        } else if (simSlot != null) {
+        } else {
             SubscriptionInfo mSubscriptionInfo =
                     mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(
                             simSlot.intValue());
@@ -87,8 +87,6 @@ public class TelephonySnippet implements Snippet {
                                 .createForSubscriptionId(mSubscriptionInfo.getSubscriptionId())
                                 .getCallStateForSubscription();
             }
-        } else {
-            thisState = mTelephonyManager.getCallState();
         }
 
         return thisState;

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -42,16 +42,17 @@ public class TelephonySnippet implements Snippet {
 
     @Rpc(
             description =
-                    "Gets the line 1 phone number, or optionally get phone number for the " +
-                            "simSlot (slot# start from 0, only valid for API level > 32)")
-    public String getLine1Number(@RpcDefault("0") int simSlot) {
+                    "Gets the line 1 phone number, or optionally get phone number for the "
+                            + "simSlot (slot# start from 0, only valid for API level > 32)")
+    public String getLine1Number(@RpcDefault("0") Integer simSlot) {
         String thisNumber = "";
 
-        if (Build.VERSION.SDK_INT < 33) {
+        if (Build.VERSION.SDK_INT < 33 || simSlot == null) {
             thisNumber = mTelephonyManager.getLine1Number();
         } else {
             SubscriptionInfo mSubscriptionInfo =
-                    mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot);
+                    mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(
+                            simSlot.intValue());
             if (mSubscriptionInfo != null) {
                 thisNumber =
                         mSubscriptionManager.getPhoneNumber(mSubscriptionInfo.getSubscriptionId());
@@ -68,23 +69,26 @@ public class TelephonySnippet implements Snippet {
 
     @Rpc(
             description =
-                    "Gets the call state for the default subscription or optionally get the call" +
-                            " state for the simSlot (slot# start from 0, only valid for API" +
-                            " level > 30). Call state values are 0: IDLE, 1: RINGING, 2: OFFHOOK")
-    public int getTelephonyCallState(@RpcDefault("0") int simSlot) {
+                    "Gets the call state for the default subscription or optionally get the call"
+                            + " state for the simSlot (slot# start from 0, only valid for API"
+                            + " level > 30). Call state values are 0: IDLE, 1: RINGING, 2: OFFHOOK")
+    public int getTelephonyCallState(@RpcDefault("0") Integer simSlot) {
         int thisState = -1;
 
         if (Build.VERSION.SDK_INT < 31) {
             return mTelephonyManager.getCallState();
-        } else {
+        } else if (simSlot != null) {
             SubscriptionInfo mSubscriptionInfo =
-                    mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot);
+                    mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(
+                            simSlot.intValue());
             if (mSubscriptionInfo != null) {
                 thisState =
                         mTelephonyManager
                                 .createForSubscriptionId(mSubscriptionInfo.getSubscriptionId())
                                 .getCallStateForSubscription();
             }
+        } else {
+            thisState = mTelephonyManager.getCallState();
         }
 
         return thisState;

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -24,7 +24,7 @@ import android.telephony.TelephonyManager;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.android.mobly.snippet.Snippet;
 import com.google.android.mobly.snippet.rpc.Rpc;
-import com.google.android.mobly.snippet.rpc.RpcOptional;
+import com.google.android.mobly.snippet.rpc.RpcDefault;
 
 /** Snippet class for telephony RPCs. */
 public class TelephonySnippet implements Snippet {
@@ -35,19 +35,26 @@ public class TelephonySnippet implements Snippet {
     public TelephonySnippet() {
         Context context = InstrumentationRegistry.getInstrumentation().getContext();
         mTelephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-        mSubscriptionManager = (SubscriptionManager) context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE);
+        mSubscriptionManager =
+                (SubscriptionManager)
+                        context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE);
     }
 
-    @Rpc(description = "Gets the line 1 phone number, or optionally get phone number for the simSlot (slot# start from 0, only valid for API level > 32)")
-    public String getLine1Number(@RpcOptional Integer simSlot) {
+    @Rpc(
+            description =
+                    "Gets the line 1 phone number, or optionally get phone number for the " +
+                            "simSlot (slot# start from 0, only valid for API level > 32)")
+    public String getLine1Number(@RpcDefault("0") int simSlot) {
         String thisNumber = "";
 
-        if (Build.VERSION.SDK_INT < 33 || simSlot == null) {
+        if (Build.VERSION.SDK_INT < 33) {
             thisNumber = mTelephonyManager.getLine1Number();
-        } else{
-            SubscriptionInfo mSubscriptionInfo = mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot.intValue());
+        } else {
+            SubscriptionInfo mSubscriptionInfo =
+                    mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot);
             if (mSubscriptionInfo != null) {
-                thisNumber = mSubscriptionManager.getPhoneNumber(mSubscriptionInfo.getSubscriptionId());
+                thisNumber =
+                        mSubscriptionManager.getPhoneNumber(mSubscriptionInfo.getSubscriptionId());
             }
         }
 
@@ -61,23 +68,23 @@ public class TelephonySnippet implements Snippet {
 
     @Rpc(
             description =
-                    "Gets the call state for the default subscription or optionally get the call state for the simSlot (slot# start from 0, only valid for API level > 30)."
-                            + " Call state values are 0: IDLE, 1: RINGING, 2: OFFHOOK")
-    public int getTelephonyCallState(@RpcOptional Integer simSlot) {
+                    "Gets the call state for the default subscription or optionally get the call" +
+                            " state for the simSlot (slot# start from 0, only valid for API" +
+                            " level > 30). Call state values are 0: IDLE, 1: RINGING, 2: OFFHOOK")
+    public int getTelephonyCallState(@RpcDefault("0") int simSlot) {
         int thisState = -1;
 
         if (Build.VERSION.SDK_INT < 31) {
             return mTelephonyManager.getCallState();
-        } else if(simSlot != null){
-            SubscriptionInfo mSubscriptionInfo = mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot.intValue());
+        } else {
+            SubscriptionInfo mSubscriptionInfo =
+                    mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot);
             if (mSubscriptionInfo != null) {
                 thisState =
                         mTelephonyManager
                                 .createForSubscriptionId(mSubscriptionInfo.getSubscriptionId())
                                 .getCallStateForSubscription();
             }
-        }else{
-            thisState = mTelephonyManager.getCallStateForSubscription();
         }
 
         return thisState;

--- a/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/TelephonySnippet.java
@@ -54,22 +54,6 @@ public class TelephonySnippet implements Snippet {
         return thisNumber;
     }
 
-    @Rpc(description = "Gets phone number for the simSlot (slot# start from 0, only valid for API level > 32)."
-                                + " API level <33 will always return phone number for simSlotIndex = 0")
-    public String getPhoneNumber(int simSlot) {
-        String thisNumber = "";
-
-        if (Build.VERSION.SDK_INT < 33) {
-            thisNumber = mTelephonyManager.getLine1Number();
-        } else {
-            SubscriptionInfo mSubscriptionInfo = mSubscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(simSlot);
-            if (mSubscriptionInfo != null) {
-                thisNumber = mSubscriptionManager.getPhoneNumber(mSubscriptionInfo.getSubscriptionId());
-            }
-        }
-        return thisNumber;
-    }
-
     @Rpc(description = "Returns the unique subscriber ID, for example, the IMSI for a GSM phone.")
     public String getSubscriberId() {
         return mTelephonyManager.getSubscriberId();


### PR DESCRIPTION
1. To address deprecated API: [public String getLine1Number ()](https://developer.android.com/reference/android/telephony/TelephonyManager#getLine1Number())
2. To allow access to multi-sim device:
2.1. Add new function: String getPhoneNumber(int simSlot)
2.2. Add new variant: int getTelephonyCallState(int simSlot)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/182)
<!-- Reviewable:end -->
