### PR TITLE
Update AndroidManifest.xml to request legacy Bluetooth permissions on older devices

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -11,8 +11,11 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+
+    <!-- Request legacy Bluetooth permissions on older devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />


### PR DESCRIPTION
https://developer.android.com/develop/connectivity/bluetooth/bt-permissions

Context:

```
Android 12 (S) and later: Google introduced significant changes to Bluetooth permissions. The older permissions BLUETOOTH and BLUETOOTH_ADMIN were replaced by two finer-grained permissions:
  - BLUETOOTH_SCAN: Allows apps to scan for nearby Bluetooth devices without having to connect to them.
  - BLUETOOTH_CONNECT: Allows apps to connect with paired Bluetooth devices.
```

Add `android:maxSdkVersion="30"` for legacy Bluetooth permissions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/186)
<!-- Reviewable:end -->
