### PR TITLE
Add the network callback for wifi connection check

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -414,9 +414,9 @@ public class WifiManagerSnippet implements Snippet {
             throw new WifiManagerSnippetException("Failed to initiate turning on Wi-Fi Soft AP.");
         }
         if (!Utils.waitUntil(() -> wifiIsApEnabled() == true, 60)) {
-      throw new WifiManagerSnippetException(
-          "Timed out after 60s waiting for Wi-Fi Soft AP state to turn on with configuration: "
-              + configuration);
+            throw new WifiManagerSnippetException(
+                    "Timed out after 60s waiting for Wi-Fi Soft AP state to turn on with configuration: "
+                            + configuration);
         }
     }
 


### PR DESCRIPTION
Use the network callback for wifi connection status check for L+ devices.

Also remove networkId check for pre-L devices as it doesn't sometimes work while the network is already connected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/195)
<!-- Reviewable:end -->
