### PR TITLE
Add the permission to post notification.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application android:allowBackup="false"
                  android:name="androidx.multidex.MultiDexApplication">
         <meta-data


### PR DESCRIPTION
Currently, no toast will occur on Android screen if we build the MBS app via `gradlew`.

As shown in the logcat, the toast is suppressed silently.

```
07-02 10:41:49.831  1399  4652 E NotificationService: Suppressing toast from package com.google.android.mobly.snippet.bundled by user request.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/196)
<!-- Reviewable:end -->
