### PR TITLE
Update SSID check in WifiManagerSnippet.java

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -109,7 +109,8 @@ public class WifiManagerSnippet implements Snippet {
     }
 
     private boolean isWifiConnectedToSsid(String ssid) {
-        return mWifiManager.getConnectionInfo().getSSID().equals(ssid);
+        return mWifiManager.getConnectionInfo().getSSID().equals(ssid)
+                || mWifiManager.getConnectionInfo().getSSID().equals(WifiManager.UNKNOWN_SSID);
     }
 
     @Rpc(


### PR DESCRIPTION
getSSID() could return UNKNOWN_SSID when the location mode is disabled. Relax the SSID check to allow UNKNOWN_SSID so that test still passes when the location mode is disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/197)
<!-- Reviewable:end -->
