### PR TITLE
Fix MBS Utils to work while being instrumented

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
@@ -217,9 +217,7 @@ public final class Utils {
     }
 
    public static void adaptShellPermissionIfRequired(Context context) throws Throwable {
-      if (context.getPackageManager().getApplicationInfo(context.getPackageName(), 0).targetSdkVersion
-            >= 29
-          && Build.VERSION.SDK_INT >= 29) {
+      if (Build.VERSION.SDK_INT >= 29) {
         Log.d("Elevating permission require to enable support for privileged operation in Android Q+");
         UiAutomation uia = InstrumentationRegistry.getInstrumentation().getUiAutomation();
         uia.adoptShellPermissionIdentity();

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
@@ -217,7 +217,8 @@ public final class Utils {
     }
 
    public static void adaptShellPermissionIfRequired(Context context) throws Throwable {
-      if (context.getApplicationContext().getApplicationInfo().targetSdkVersion >= 29
+      if (context.getPackageManager().getApplicationInfo(context.getPackageName(), 0).targetSdkVersion
+            >= 29
           && Build.VERSION.SDK_INT >= 29) {
         Log.d("Elevating permission require to enable support for privileged operation in Android Q+");
         UiAutomation uia = InstrumentationRegistry.getInstrumentation().getUiAutomation();


### PR DESCRIPTION
An instrumented context's getApplicationContext() may return null and throw.

In particular this can happen when using the BluetoothAdapterSnippet. Instead we get the applicationInfo from the packageManager.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/199)
<!-- Reviewable:end -->
