### PR TITLE
Upgrade Gradle version to 8.11 and AGP version to 8.7.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.7.3'
 
         // NOTE: Do not place your application dependencies here.
     }
@@ -50,12 +50,13 @@ android {
         warningsAsErrors true
         disable 'HardwareIds','MissingApplicationIcon','GoogleAppIndexingWarning','InvalidPackage','OldTargetApi'
     }
+    namespace 'com.google.android.mobly.snippet.bundled'
 }
 
 // Produces a jar of source files. Needed for compliance reasons.
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier = 'src'
+    archiveClassifier.set('src')
 }
 
 task javadoc(type: Javadoc) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.jvmargs=-Xmx1536M
 android.enableD8.desugaring=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 14 02:01:02 CST 2021
+#Mon Dec 16 18:55:43 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.android.mobly.snippet.bundled">
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 

--- a/src/test/java/UtilsTest.java
+++ b/src/test/java/UtilsTest.java
@@ -56,7 +56,7 @@ public class UtilsTest {
         List<?> sampleList = Collections.singletonList("sampleList");
         ReflectionTest_HostClass hostClass = new ReflectionTest_HostClass();
         Object ret = invokeByReflection(hostClass, "returnSame", sampleList);
-        Truth.assertThat(ret).isSameAs(sampleList);
+        Truth.assertThat(ret).isEqualTo(sampleList);
     }
 
     @Test
@@ -87,11 +87,11 @@ public class UtilsTest {
         Object arg2 = new Object();
         Object ret =
                 invokeByReflection(hostClass, "multiArgCall", arg1, arg2, true /* returnArg1 */);
-        Truth.assertThat(ret).isSameAs(arg1);
+        Truth.assertThat(ret).isEqualTo(arg1);
         ret =
                 Utils.invokeByReflection(
                         hostClass, "multiArgCall", arg1, arg2, false /* returnArg1 */);
-        Truth.assertThat(ret).isSameAs(arg2);
+        Truth.assertThat(ret).isEqualTo(arg2);
     }
 
     @Test


### PR DESCRIPTION
After updating the Gradle and AGP version to the latest and replacing the outdated API `Truth.assertThat#isSameAs`, the APK is now able to be built via Android Studio and gradlew tool.

Fixes #213

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/214)
<!-- Reviewable:end -->
