### PR TITLE
Add RpcEnum::getIntBitwiseOr() Helper API (1/3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ android {
         versionName "0.0.1"
         setProperty("archivesBaseName", "mobly-bundled-snippets")
         multiDexEnabled true
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -79,6 +80,7 @@ dependencies {
     implementation 'com.google.errorprone:error_prone_annotations:2.15.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10'
 
+    testImplementation 'org.robolectric:robolectric:4.14.1'
     testImplementation 'com.google.errorprone:error_prone_annotations:2.15.0'
     testImplementation 'com.google.guava:guava:31.0.1-jre'
     testImplementation 'com.google.truth:truth:1.1.2'

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/MbsEnums.java
@@ -40,7 +40,7 @@ public class MbsEnums {
     static final RpcEnum BLE_SERVICE_TYPE = buildServiceTypeEnum();
     public static final RpcEnum BLE_STATUS_TYPE = buildStatusTypeEnum();
     public static final RpcEnum BLE_CONNECT_STATUS = buildConnectStatusEnum();
-    static final RpcEnum BLE_PROPERTY_TYPE = buildPropertyTypeEnum();
+    public static final RpcEnum BLE_PROPERTY_TYPE = buildPropertyTypeEnum();
     static final RpcEnum BLE_PERMISSION_TYPE = buildPermissionTypeEnum();
     static final RpcEnum BLE_SCAN_MODE = buildBleScanModeEnum();
     public static final RpcEnum LOCAL_HOTSPOT_FAIL_REASON = buildLocalHotspotFailedReason();

--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/RpcEnum.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/RpcEnum.java
@@ -16,6 +16,7 @@
 
 package com.google.android.mobly.snippet.bundled.utils;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
@@ -44,6 +45,22 @@ public class RpcEnum {
         Integer result = enums.get(enumString);
         if (result == null) {
             throw new NoSuchFieldError("No int value found for: " + enumString);
+        }
+        return result;
+    }
+
+    /**
+     * Get the int value of an enum based on its String value. String value contains multiple enums
+     * separated by '|'. The int value is the bitwise OR of all the enums.
+     *
+     * @param enumString
+     * @return int value
+     */
+    public int getIntBitwiseOr(String enumString) {
+        Integer result = 0;
+        Iterable<String> enumList = Splitter.on('|').split(enumString);
+        for (String enumEntry : enumList) {
+            result |= getInt(enumEntry);
         }
         return result;
     }

--- a/src/test/java/MbsEnumsTest.java
+++ b/src/test/java/MbsEnumsTest.java
@@ -1,0 +1,42 @@
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.os.Build.VERSION_CODES;
+import com.google.android.mobly.snippet.bundled.utils.MbsEnums;
+import com.google.common.truth.Truth;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.runner.AndroidJUnitRunner;
+import org.junit.runners.JUnit4;
+import org.robolectric.annotation.Config;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = 33)
+public class MbsEnumsTest {
+  @Test
+  public void testGetIntBitwiseOrValid() throws Throwable {
+    Truth.assertThat(MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr("PROPERTY_READ|PROPERTY_NOTIFY")).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_NOTIFY);
+    Truth.assertThat(MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr("PROPERTY_READ")).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ);
+  }
+
+  @Test
+  public void testGetIntBitwiseOrInvalid() throws Throwable {
+    Throwable thrown = null;
+    try {
+      MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr("PROPERTY_NOTHING");
+    } catch (Throwable t) {
+      thrown = t;
+    }
+    Truth.assertThat(thrown).isInstanceOf(NoSuchFieldError.class);
+  }
+
+  @Test
+  public void testGetIntBitwiseOrInvalid2() throws Throwable {
+    Throwable thrown = null;
+    try {
+      MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr("PROPERTY_READ|PROPERTY_NOTHING");
+    } catch (Throwable t) {
+      thrown = t;
+    }
+    Truth.assertThat(thrown).isInstanceOf(NoSuchFieldError.class);
+  }
+}


### PR DESCRIPTION
Change `property` and `permission` fields to plural in `BluetoothGattCharacteristic`.
Because multiple BluetoothGattCharacteristic can be contained in one event field.

https://developer.android.com/reference/android/bluetooth/BluetoothGattCharacteristic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/223)
<!-- Reviewable:end -->
