### PR TITLE
Revert "Update JsonDeserializer::jsonToBluetoothGattCharacteristic"

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
@@ -130,12 +130,8 @@ public class JsonDeserializer {
         BluetoothGattCharacteristic characteristic =
                 new BluetoothGattCharacteristic(
                         UUID.fromString(jsonObject.getString("UUID")),
-                        // A characteristic can have multiple properties (e.g. PROPERTY_READ and PROPERTY_WRITE).
-                        // Use the BitwiseOr to extract all the properties from the json string.
-                        MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr(jsonObject.getString("Properties")),
-                        // A characteristic can have multiple permissions (e.g. PERMISSION_READ and PERMISSION_WRITE).
-                        // Use the BitwiseOr to extract all the permissions from the json string.
-                        MbsEnums.BLE_PERMISSION_TYPE.getIntBitwiseOr(jsonObject.getString("Permissions")));
+                        MbsEnums.BLE_PROPERTY_TYPE.getInt(jsonObject.getString("Property")),
+                        MbsEnums.BLE_PERMISSION_TYPE.getInt(jsonObject.getString("Permission")));
         if (jsonObject.has("Data")) {
               dataHolder.insertData(characteristic, jsonObject.getString("Data"));
         }


### PR DESCRIPTION
Reverts google/mobly-bundled-snippets#224 due to builder error

```
src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java:135: error: cannot find symbol
                        MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr(jsonObject.getString("Properties")),
                                                  ^
  symbol:   method getIntBitwiseOr(String)
  location: variable BLE_PROPERTY_TYPE of type RpcEnum

src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java:138: error: cannot find symbol
                        MbsEnums.BLE_PERMISSION_TYPE.getIntBitwiseOr(jsonObject.getString("Permissions")));
                                                    ^
  symbol:   method getIntBitwiseOr(String)
  location: variable BLE_PERMISSION_TYPE of type RpcEnum
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/227)
<!-- Reviewable:end -->
