### PR TITLE
Support for specifying BSSID in Wi-Fi config

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
@@ -50,6 +50,9 @@ public class JsonDeserializer {
         } else {
             config.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);
         }
+        if (jsonObject.has("BSSID")) {
+            config.BSSID = jsonObject.getString("BSSID");
+        }
         return config;
     }
 


### PR DESCRIPTION
Example usage:

```
ad.mbs.wifiConnect({'SSID': 'MyWiFi', 'BSSID': 'a1:b2:c3:d4:e5:f6'}, 'password': '12345678')
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/233)
<!-- Reviewable:end -->
