### PR TITLE
Add backwards compatibility or Property/Permission

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
@@ -130,15 +130,30 @@ public class JsonDeserializer {
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public static BluetoothGattCharacteristic jsonToBluetoothGattCharacteristic(
             DataHolder dataHolder, JSONObject jsonObject) throws JSONException {
+        // A characteristic can have multiple properties (e.g. PROPERTY_READ and PROPERTY_WRITE).
+        // Use the BitwiseOr to extract all the properties from the json string.
+        String properties = "";
+        if (jsonObject.has("Properties")) {
+            properties = jsonObject.getString("Properties");
+        } else if (jsonObject.has("Property")) {
+            // Previously the API expected `Property` not `Properties`
+            properties = jsonObject.getString("Property");
+        }
+
+        // A characteristic can have multiple permissions (e.g. PERMISSION_READ and PERMISSION_WRITE).
+        // Use the BitwiseOr to extract all the permissions from the json string.
+        String permissions = "";
+        if (jsonObject.has("Permissions")) {
+            permissions = jsonObject.getString("Permissions");
+        } else if (jsonObject.has("Permission")) {
+            // Previously the API expected `Permission` not `Permissions`
+            permissions = jsonObject.getString("Permission");
+        }
         BluetoothGattCharacteristic characteristic =
                 new BluetoothGattCharacteristic(
                         UUID.fromString(jsonObject.getString("UUID")),
-                        // A characteristic can have multiple properties (e.g. PROPERTY_READ and PROPERTY_WRITE).
-                        // Use the BitwiseOr to extract all the properties from the json string.
-                        MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr(jsonObject.getString("Properties")),
-                        // A characteristic can have multiple permissions (e.g. PERMISSION_READ and PERMISSION_WRITE).
-                        // Use the BitwiseOr to extract all the permissions from the json string.
-                        MbsEnums.BLE_PERMISSION_TYPE.getIntBitwiseOr(jsonObject.getString("Permissions")));
+                        MbsEnums.BLE_PROPERTY_TYPE.getIntBitwiseOr(properties),
+                        MbsEnums.BLE_PERMISSION_TYPE.getIntBitwiseOr(permissions));
         if (jsonObject.has("Data")) {
               dataHolder.insertData(characteristic, jsonObject.getString("Data"));
         }

--- a/src/test/java/JsonDeserializerTest.java
+++ b/src/test/java/JsonDeserializerTest.java
@@ -1,0 +1,65 @@
+import android.bluetooth.BluetoothGattCharacteristic;
+import com.google.android.mobly.snippet.bundled.utils.JsonDeserializer;
+import com.google.android.mobly.snippet.bundled.utils.MbsEnums;
+import com.google.common.truth.Truth;
+import java.util.UUID;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = 33)
+public class JsonDeserializerTest {
+  @Test
+  public void testCharacteristicWithPropertiesPermissions() throws Throwable {
+    JSONObject json = new JSONObject();
+    json.put("UUID", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+    json.put("Properties", "PROPERTY_READ");
+    json.put("Permissions", "PERMISSION_READ");
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, json);
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ);
+  }
+
+  @Test
+  public void testCharacteristicWithMultiplePropertiesPermissions() throws Throwable {
+    JSONObject json = new JSONObject();
+    json.put("UUID", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+    json.put("Properties", "PROPERTY_READ|PROPERTY_WRITE");
+    json.put("Permissions", "PERMISSION_READ|PERMISSION_WRITE");
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, json);
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_WRITE);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ |BluetoothGattCharacteristic.PERMISSION_WRITE);
+  }
+
+  public void testCharacteristicWithPropertyPermission() throws Throwable {
+    JSONObject json = new JSONObject();
+    json.put("UUID", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+    json.put("Property", "PROPERTY_READ");
+    json.put("Permission", "PERMISSION_READ");
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, json);
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ);
+  }
+
+  @Test
+  public void testCharacteristicWithMultiplePropertyPermission() throws Throwable {
+    JSONObject json = new JSONObject();
+    json.put("UUID", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+    json.put("Property", "PROPERTY_READ|PROPERTY_WRITE");
+    json.put("Permission", "PERMISSION_READ|PERMISSION_WRITE");
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, json);
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_WRITE);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ |BluetoothGattCharacteristic.PERMISSION_WRITE);
+  }
+}


### PR DESCRIPTION
PR #224 changed the API Properties/Permissions to match the Android API.

This CL adds back the old API to ensure no regressions for existing users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/234)
<!-- Reviewable:end -->
