### PR TITLE
Include IdentityAddress for BluetoothDevice in JsonSerializer.java

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonSerializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonSerializer.java
@@ -134,6 +134,7 @@ public class JsonSerializer {
     public static Bundle serializeBluetoothDevice(BluetoothDevice data) {
         Bundle result = new Bundle();
         result.putString("Address", data.getAddress());
+        result.putString("IdentityAddress", data.getIdentityAddressWithType().getAddress());
         final String bondState =
                 MbsEnums.BLUETOOTH_DEVICE_BOND_STATE.getString(data.getBondState());
         result.putString("BondState", bondState);


### PR DESCRIPTION
When Bt bonds over LE the, getAddress() on btGetPairedDevices() will return a randomized bt address. This causes asserts in bt bonding because the device is comparing the randomized public address with its private identity address. Adding the identity address in the bluetooth device bundle will allow validation that devices are bonded

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/236)
<!-- Reviewable:end -->
