### PR TITLE
Migrate buildConfig setting and remove deprecated desugaring flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ apply plugin: 'com.android.application'
 android {
     compileSdk 33
 
+    buildFeatures {
+        buildConfig = true
+    }
     defaultConfig {
         applicationId "com.google.android.mobly.snippet.bundled"
         minSdk 26

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ android {
         targetSdk 33
         versionCode 1
         versionName "0.0.1"
-        setProperty("archivesBaseName", "mobly-bundled-snippets")
         multiDexEnabled true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,5 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableD8.desugaring=true
 android.useAndroidX=true
 android.enableJetifier=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Removes deprecated Android Gradle properties from gradle.properties:

- Migrates `android.defaults.buildfeatures.buildconfig=true` to the `android.buildFeatures` block in module build.gradle files.
- Removes the obsolete `android.enableD8.desugaring` flag.

This addresses build warnings and aligns with current AGP best practices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/237)
<!-- Reviewable:end -->
