### PR TITLE
Add BluetoothGattDescriptor support

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/JsonDeserializer.java
@@ -18,6 +18,7 @@ package com.google.android.mobly.snippet.bundled.utils;
 
 import android.annotation.TargetApi;
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.bluetooth.le.AdvertiseData;
 import android.bluetooth.le.AdvertiseSettings;
@@ -139,10 +140,30 @@ public class JsonDeserializer {
                         // A characteristic can have multiple permissions (e.g. PERMISSION_READ and PERMISSION_WRITE).
                         // Use the BitwiseOr to extract all the permissions from the json string.
                         MbsEnums.BLE_PERMISSION_TYPE.getIntBitwiseOr(jsonObject.getString("Permissions")));
+        JSONArray descriptors = jsonObject.optJSONArray("Descriptors");
+        if (descriptors != null) {
+            for (int i = 0; i < descriptors.length(); i++) {
+                BluetoothGattDescriptor descriptor =
+                        jsonToBluetoothGattDescriptor(descriptors.getJSONObject(i));
+                characteristic.addDescriptor(descriptor);
+            }
+        }
         if (jsonObject.has("Data")) {
               dataHolder.insertData(characteristic, jsonObject.getString("Data"));
         }
         return characteristic;
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public static BluetoothGattDescriptor jsonToBluetoothGattDescriptor(
+            JSONObject jsonObject) throws JSONException {
+        BluetoothGattDescriptor descriptor =
+                new BluetoothGattDescriptor(
+                        UUID.fromString(jsonObject.getString("UUID")),
+                        // A descriptor can have multiple permissions (e.g. PERMISSION_READ and PERMISSION_WRITE).
+                        // Use the BitwiseOr to extract all the permissions from the json string.
+                        MbsEnums.BLE_PERMISSION_TYPE.getIntBitwiseOr(jsonObject.getString("Permissions")));
+        return descriptor;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/src/test/java/JsonDeserializerTest.java
+++ b/src/test/java/JsonDeserializerTest.java
@@ -15,6 +15,8 @@
  */
 
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+
 import com.google.android.mobly.snippet.bundled.utils.JsonDeserializer;
 import com.google.common.truth.Truth;
 import java.util.UUID;
@@ -55,5 +57,106 @@ public class JsonDeserializerTest {
     Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString(uuid));
     Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_WRITE);
     Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ |BluetoothGattCharacteristic.PERMISSION_WRITE);
+  }
+
+  @Test
+  public void testDescriptor() throws Throwable {
+    String jsonString =
+            "{" +
+            "  \"UUID\": \"ffffffff-ffff-ffff-ffff-ffffffffffff\"," +
+            "  \"Permissions\": \"PERMISSION_READ|PERMISSION_WRITE\"" +
+            "}";
+
+    BluetoothGattDescriptor descriptor = JsonDeserializer.jsonToBluetoothGattDescriptor(new JSONObject(jsonString));
+    Truth.assertThat(descriptor.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(descriptor.getPermissions()).isEqualTo(BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE);
+  }
+
+  @Test
+  public void testCharacteristicNoDescriptors() throws Throwable {
+    String jsonString =
+            "{" +
+            "  \"UUID\": \"ffffffff-ffff-ffff-ffff-ffffffffffff\"," +
+            "  \"Properties\":\"PROPERTY_READ|PROPERTY_WRITE\"," +
+            "  \"Permissions\": \"PERMISSION_READ|PERMISSION_WRITE\"" +
+            "}";
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, new JSONObject(jsonString));
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_WRITE);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ | BluetoothGattCharacteristic.PERMISSION_WRITE);
+    Truth.assertThat(characteristic.getDescriptors()).isEmpty();
+  }
+
+  @Test
+  public void testCharacteristicEmptyListDescriptors() throws Throwable {
+    String jsonString =
+            "{" +
+            "  \"UUID\": \"ffffffff-ffff-ffff-ffff-ffffffffffff\"," +
+            "  \"Properties\":\"PROPERTY_READ|PROPERTY_WRITE\"," +
+            "  \"Permissions\": \"PERMISSION_READ|PERMISSION_WRITE\"," +
+            "  \"Descriptors\": []" +
+            "}";
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, new JSONObject(jsonString));
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_WRITE);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ | BluetoothGattCharacteristic.PERMISSION_WRITE);
+    Truth.assertThat(characteristic.getDescriptors()).isEmpty();
+  }
+
+  @Test
+  public void testCharacteristic1Descriptor() throws Throwable {
+    String jsonString =
+            "{" +
+            "  \"UUID\": \"ffffffff-ffff-ffff-ffff-ffffffffffff\"," +
+            "  \"Properties\":\"PROPERTY_READ|PROPERTY_WRITE\"," +
+            "  \"Permissions\": \"PERMISSION_READ|PERMISSION_WRITE\"," +
+            "  \"Descriptors\":" +
+            "  [" +
+            "    {" +
+            "      \"UUID\": \"dddddddd-dddd-dddd-dddd-dddddddddddd\"," +
+            "      \"Permissions\": \"PERMISSION_READ|PERMISSION_WRITE\"" +
+            "    }" +
+            "  ]" +
+            "}";
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, new JSONObject(jsonString));
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_WRITE);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ | BluetoothGattCharacteristic.PERMISSION_WRITE);
+    Truth.assertThat(characteristic.getDescriptors().size()).isEqualTo(1);
+    Truth.assertThat(characteristic.getDescriptors().get(0).getUuid()).isEqualTo(UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd"));
+    Truth.assertThat(characteristic.getDescriptors().get(0).getPermissions()).isEqualTo(BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE);
+  }
+  @Test
+  public void testCharacteristic2Descriptors() throws Throwable {
+    String jsonString =
+            "{" +
+            "  \"UUID\": \"ffffffff-ffff-ffff-ffff-ffffffffffff\"," +
+            "  \"Properties\":\"PROPERTY_READ|PROPERTY_WRITE\"," +
+            "  \"Permissions\": \"PERMISSION_READ|PERMISSION_WRITE\"," +
+            "  \"Descriptors\":" +
+            "  [" +
+            "    {" +
+            "      \"UUID\": \"dddddddd-dddd-dddd-dddd-dddddddddddd\"," +
+            "      \"Permissions\": \"PERMISSION_READ|PERMISSION_WRITE\"" +
+            "    }," +
+            "    {" +
+            "      \"UUID\": \"eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee\"," +
+            "      \"Permissions\": \"PERMISSION_READ\"" +
+            "    }" +
+            "  ]" +
+            "}";
+
+    BluetoothGattCharacteristic characteristic = JsonDeserializer.jsonToBluetoothGattCharacteristic(null, new JSONObject(jsonString));
+    Truth.assertThat(characteristic.getUuid()).isEqualTo(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    Truth.assertThat(characteristic.getProperties()).isEqualTo(BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_WRITE);
+    Truth.assertThat(characteristic.getPermissions()).isEqualTo(BluetoothGattCharacteristic.PERMISSION_READ | BluetoothGattCharacteristic.PERMISSION_WRITE);
+    Truth.assertThat(characteristic.getDescriptors().size()).isEqualTo(2);
+    Truth.assertThat(characteristic.getDescriptors().get(0).getUuid()).isEqualTo(UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd"));
+    Truth.assertThat(characteristic.getDescriptors().get(0).getPermissions()).isEqualTo(BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE);
+    Truth.assertThat(characteristic.getDescriptors().get(1).getUuid()).isEqualTo(UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"));
+    Truth.assertThat(characteristic.getDescriptors().get(1).getPermissions()).isEqualTo(BluetoothGattDescriptor.PERMISSION_READ);
   }
 }


### PR DESCRIPTION
This PR adds support to adding descriptors to a BluetoothGattCharacteristic.

See:
* https://developer.android.com/reference/android/bluetooth/BluetoothGattDescriptor#BluetoothGattDescriptor(java.util.UUID,%20int)
* https://developer.android.com/reference/android/bluetooth/BluetoothGattCharacteristic#addDescriptor(android.bluetooth.BluetoothGattDescriptor)

Descriptors are needed to support GATT notifications/indications.

Validated by adding unit tests and running on device and confirming that GATT notifications work

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/239)
<!-- Reviewable:end -->
