### PR TITLE
Add display name to Mobly Bundled Snippets app.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <application android:allowBackup="false">
+    <application android:allowBackup="false" android:label="MoblyBundledSnippetsApp">
         <meta-data
             android:name="mobly-snippets"
             android:testOnly="true"


### PR DESCRIPTION
Add an application label in the AndroidManifest.xml.

With this CL, dialogs and settings app will use `MoblyBundledSnippetsApp` as the snippet name instead of a default string `androidx.multidex.MultiDexApplication`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/252)
<!-- Reviewable:end -->
