### PR TITLE
Keep adopted shell permission identity active in Mobly snippets

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
@@ -236,19 +236,7 @@ public final class Utils {
                         + Arrays.toString(permissions));
                 uia.adoptShellPermissionIdentity(permissions);
             }
-            // Need to drop the UI Automation to allow other snippets to get access
-            // to global UI automation.
-            // Using reflection here since the method is not public.
-            try {
-                Class<?> cls = Class.forName("android.app.UiAutomation");
-                Method destroyMethod = cls.getDeclaredMethod("destroy");
-                destroyMethod.invoke(uia);
-            } catch (NoSuchMethodException
-                    | IllegalAccessException
-                    | ClassNotFoundException
-                    | InvocationTargetException e) {
-                throw new RuntimeException("Failed to cleaup Ui Automation", e);
-            }
+
         }
     }
 


### PR DESCRIPTION
This PR removes the reflection-based call to UiAutomation.destroy().

Previously, the snippet attempted to manually tear down UiAutomation using reflection to allow other snippets to access global UI automation. However, destroying UiAutomation immediately also drops the shell permission identity that was just adopted.

By removing this manual teardown, the adopted shell permissions remain active so that subsequent snippet operations can continue to use them without issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/253)
<!-- Reviewable:end -->
