### PR TITLE
Avoid destroying UiAutomation to keep adopted permissions

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/utils/Utils.java
@@ -236,18 +236,20 @@ public final class Utils {
                         + Arrays.toString(permissions));
                 uia.adoptShellPermissionIdentity(permissions);
             }
-            // Need to drop the UI Automation to allow other snippets to get access
-            // to global UI automation.
-            // Using reflection here since the method is not public.
-            try {
-                Class<?> cls = Class.forName("android.app.UiAutomation");
-                Method destroyMethod = cls.getDeclaredMethod("destroy");
-                destroyMethod.invoke(uia);
-            } catch (NoSuchMethodException
-                    | IllegalAccessException
-                    | ClassNotFoundException
-                    | InvocationTargetException e) {
-                throw new RuntimeException("Failed to cleaup Ui Automation", e);
+            if (Build.VERSION.SDK_INT < 37) {
+                // Need to drop the UI Automation to allow other snippets to get access
+                // to global UI automation.
+                // Using reflection here since the method is not public.
+                try {
+                    Class<?> cls = Class.forName("android.app.UiAutomation");
+                    Method destroyMethod = cls.getDeclaredMethod("destroy");
+                    destroyMethod.invoke(uia);
+                } catch (NoSuchMethodException
+                        | IllegalAccessException
+                        | ClassNotFoundException
+                        | InvocationTargetException e) {
+                    throw new RuntimeException("Failed to cleanup Ui Automation", e);
+                }
             }
         }
     }


### PR DESCRIPTION
Calling UiAutomation.destroy() revokes adopted permissions. This causes SecurityException in subsequent tests that rely on adopted permissions (e.g., LOCAL_MAC_ADDRESS for Bluetooth APIs).

Previously, calling destroy() was abusing a platform leakage where adopted permissions persisted even after the UiAutomation connection was destroyed. Since we are fixing this leakage in the platform CLs, we can no longer call destroy() if we want the permissions to persist.

It is fine to remove destroy() because:
- The UiAutomation connection remains active for the lifetime of the snippet runner process.
- While this locks the system-wide UiAutomation connection and prevents other processes from obtaining a new connection concurrently, this is acceptable for CTS/Mobly since tests run sequentially and the connection is released when the snippet process terminates.
- Other snippets within the same process can still share the cached UiAutomation instance via InstrumentationRegistry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/254)
<!-- Reviewable:end -->
