### PR TITLE
Add wifiDisconnect RPC to WifiManagerSnippet

### DIFF
--- a/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
+++ b/src/main/java/com/google/android/mobly/snippet/bundled/WifiManagerSnippet.java
@@ -96,6 +96,28 @@ public class WifiManagerSnippet implements Snippet {
             });
     }
 
+    /**
+     * Disconnects from the currently connected Wi-Fi network.
+     *
+     * <p>{@link WifiManager#disconnect()} is a privileged API: on API 29+ it is a no-op that
+     * returns {@code false} unless the snippet process holds the required system permissions.
+     */
+    @Rpc(description = "Disconnects from the currently connected Wi-Fi network with a 30s timeout.")
+    public void wifiDisconnect() throws InterruptedException, WifiManagerSnippetException {
+        if (!isWifiConnected()) {
+            return;
+        }
+        if (!mWifiManager.disconnect()) {
+            throw new WifiManagerSnippetException("Failed to initiate Wi-Fi disconnection.");
+        }
+        if (!Utils.waitUntil(() -> !isWifiConnected(), TIMEOUT_TOGGLE_STATE)) {
+            throw new WifiManagerSnippetException(
+                    String.format(
+                            "Failed to disconnect from Wi-Fi after %ss, timeout!",
+                            TIMEOUT_TOGGLE_STATE));
+        }
+    }
+
     @Rpc(description = "Checks if Wi-Fi is connected.")
     public boolean isWifiConnected() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
Adds a `wifiDisconnect` RPC to `WifiManagerSnippet` so tests can drop the current Wi-Fi association without toggling the adapter off and on.

`WifiManager.disconnect()` returns `false` when the caller lacks the privileged permissions required on API 29+, so the return value is checked and a `WifiManagerSnippetException` is thrown on failure, matching the error handling used by the other RPCs in this class.

Tested on an API 35 emulator via the snippet server: the RPC is registered and returns successfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-bundled-snippets/255)
<!-- Reviewable:end -->
